### PR TITLE
Improve performance when process a large number of orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ In migrating your Shopware 5 shop, you can either perform the migration locally 
 
 The Migration Connector provides API endpoints that allow Shopware 6 to establish a secure data connection with the active Shopware 5 shop. As long as you are using Shopware 6, you should leave the plugin enabled. This is the only way to update the data at any time.
 
+## Info for Magento 1.9 users
+
+If you want to process a large number of orders you can increase the performance by adding a MySQL index to your magento database.
+
+```ALTER TABLE `sales_flat_order_item` ADD INDEX (`parent_item_id`);```
 
 
 ## Get started with the Migration Assistant:


### PR DESCRIPTION
Shopware Migration runs query like

SELECT item.parent_id as identifier, `item`.`entity_id` AS `item.entity_id`, `item`.`parent_id` AS `item.parent_id`, `item`.`row_total` AS `item.row_total`, `item`.`price` AS `item.price`, `item`.`weight` AS `item.weight`, `item`.`qty` AS `item.qty`, `item`.`product_id` AS `item.product_id`, `item`.`order_item_id` AS `item.order_item_id`, `item`.`additional_data` AS `item.additional_data`, `item`.`description` AS `item.description`, `item`.`name` AS `item.name`, `item`.`sku` AS `item.sku`, childOrderItem.item_id as `item.child_item_id` FROM sales_flat_shipment_item item LEFT JOIN sales_flat_order_item childOrderItem ON childOrderItem.parent_item_id = item.order_item_id WHERE item.parent_id in ('64252', '5481', '5048', '64265', '5253', '5112', '6217', '6383', '4935', '5166', '5042', '5001', '5247', '136096', '6273', '6208', '4931', '5162', '5037', '4997', '5237', '64272', '5108', '64285', '6267', '6203', '4927', '64292', '5152', '5033', '5102', '4993', '5229', '6263', '6198', '4922', '5148', '5028', '136103', '64297', '64300', '4987', '5225', '8147', '6255', '6194', '4918', '5144', '5024', '5218', '4983', '5097', '64303', '6250', '6183', '4910', '5019', '5140', '64307', '5093', '5214', '4979', '6245', '6178', '64310', '4905', '6786', '4378', '4971', '5209', '64313', '64316', '5085', '6241', '6235', '5081', '6174', '5015', '5205', '5130', '64320', '4967', '4900', '64323', '4896', '4559', '5126', '5011', '4963', '5199', '5075', '4873', '6230', '6168', '4891', '64327', '5122', '6225')

Without index on sales_flat_order_item.parent_item_id Query Tooks round about 17s on our testing setup. Adding index reduce time to 50ms.