### PR TITLE
Fix migration of comma-separated tracking codes (e.g. DHL)

### DIFF
--- a/Profile/Shopware/Converter/OrderConverter.php
+++ b/Profile/Shopware/Converter/OrderConverter.php
@@ -744,7 +744,7 @@ abstract class OrderConverter extends ShopwareConverter
         }
 
         if (isset($data['trackingcode']) && $data['trackingcode'] !== '') {
-            $delivery['trackingCode'] = $data['trackingcode'];
+            $delivery['trackingCodes'] = \explode(',', $data['trackingcode']);
         }
 
         if (isset($converted['lineItems'])) {


### PR DESCRIPTION
In a previously used Shopware 5 setup I was using Pickware DHL Adapter to create shipments, but were not able to migrate the tracking codes created by this plugin. Therefore I fixed this issues by also migrating multiple tracking codes, which are provided as a comma-separated string.
My fix might not fit all use cases, nevertheless I want to provide my solution to you.