### PR TITLE
Allow returning write results in classes implementing the WriterInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - MIG-187 - Improves the migration of media without filename
 - MIG-188 - Improves media download stability
 - MIG-189 - Fix migration of product line items
+- Improve the extendability of the plugin
 
 # 2.2.2
 - MIG-110 - Improves the migration of media

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -5,6 +5,7 @@
 - MIG-187 - Verbessert die Migration von Medien ohne Dateinamen
 - MIG-188 - Verbessert die Stabilität des Mediendownloads
 - MIG-189 - Korrigiert die Migration der Produkt-Bestellpositionen
+- Verbessert die Erweiterbarkeit des Plugins
 
 # 2.2.2
 - MIG-110 - Verbessert die Migration der Medien

--- a/DependencyInjection/writer.xml
+++ b/DependencyInjection/writer.xml
@@ -81,10 +81,11 @@
             <tag name="shopware.migration.writer"/>
         </service>
 
-        <service id="SwagMigrationAssistant\Migration\Writer\OrderWriter">
+        <service id="SwagMigrationAssistant\Migration\Writer\OrderWriter"
+                 parent="SwagMigrationAssistant\Migration\Writer\AbstractWriter">
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter"/>
-            <argument type="service" id="Shopware\Core\Framework\Struct\Serializer\StructNormalizer"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\OrderDefinition"/>
+            <argument type="service" id="Shopware\Core\Framework\Struct\Serializer\StructNormalizer"/>
             <tag name="shopware.migration.writer"/>
         </service>
 

--- a/Migration/Writer/AbstractWriter.php
+++ b/Migration/Writer/AbstractWriter.php
@@ -30,14 +30,17 @@ abstract class AbstractWriter implements WriterInterface
         $this->definition = $definition;
     }
 
-    public function writeData(array $data, Context $context): void
+    public function writeData(array $data, Context $context): array
     {
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($data): void {
-            $this->entityWriter->upsert(
+        $writeResults = [];
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($data, &$writeResults): void {
+            $writeResults = $this->entityWriter->upsert(
                 $this->definition,
                 $data,
                 WriteContext::createFromContext($context)
             );
         });
+
+        return $writeResults;
     }
 }

--- a/Migration/Writer/OrderWriter.php
+++ b/Migration/Writer/OrderWriter.php
@@ -10,32 +10,23 @@ namespace SwagMigrationAssistant\Migration\Writer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Struct\Serializer\StructNormalizer;
 use SwagMigrationAssistant\Migration\DataSelection\DefaultEntities;
 
-class OrderWriter implements WriterInterface
+class OrderWriter extends AbstractWriter
 {
-    /**
-     * @var EntityWriterInterface
-     */
-    private $entityWriter;
-
     /**
      * @var StructNormalizer
      */
     private $structNormalizer;
 
-    /**
-     * @var EntityDefinition
-     */
-    private $definition;
-
-    public function __construct(EntityWriterInterface $entityWriter, StructNormalizer $structNormalizer, EntityDefinition $definition)
-    {
-        $this->entityWriter = $entityWriter;
+    public function __construct(
+        EntityWriterInterface $entityWriter,
+        EntityDefinition $definition,
+        StructNormalizer $structNormalizer
+    ) {
+        parent::__construct($entityWriter, $definition);
         $this->structNormalizer = $structNormalizer;
-        $this->definition = $definition;
     }
 
     public function supports(): string
@@ -43,7 +34,7 @@ class OrderWriter implements WriterInterface
         return DefaultEntities::ORDER;
     }
 
-    public function writeData(array $data, Context $context): void
+    public function writeData(array $data, Context $context): array
     {
         foreach ($data as &$item) {
             foreach ($item['transactions'] as &$transaction) {
@@ -53,12 +44,6 @@ class OrderWriter implements WriterInterface
         }
         unset($item);
 
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($data): void {
-            $this->entityWriter->upsert(
-                $this->definition,
-                $data,
-                WriteContext::createFromContext($context)
-            );
-        });
+        return parent::writeData($data, $context);
     }
 }

--- a/Migration/Writer/TranslationWriter.php
+++ b/Migration/Writer/TranslationWriter.php
@@ -36,7 +36,7 @@ class TranslationWriter implements WriterInterface
         return DefaultEntities::TRANSLATION;
     }
 
-    public function writeData(array $data, Context $context): void
+    public function writeData(array $data, Context $context): array
     {
         $translationArray = [];
         foreach ($data as $translationData) {
@@ -45,14 +45,17 @@ class TranslationWriter implements WriterInterface
             $translationArray[$entityDefinitionClass][] = $translationData;
         }
 
+        $writeResults = [];
         foreach ($translationArray as $entityDefinitionClass => $translation) {
-            $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($entityDefinitionClass, $translation): void {
-                $this->entityWriter->upsert(
+            $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($entityDefinitionClass, $translation, &$writeResults): void {
+                $writeResults[] = $this->entityWriter->upsert(
                     $this->registry->get($entityDefinitionClass),
                     $translation,
                     WriteContext::createFromContext($context)
                 );
             });
         }
+
+        return $writeResults;
     }
 }

--- a/Migration/Writer/WriterInterface.php
+++ b/Migration/Writer/WriterInterface.php
@@ -19,5 +19,5 @@ interface WriterInterface
     /**
      * Writes the converted data of the supported entity type into the database
      */
-    public function writeData(array $data, Context $context): void;
+    public function writeData(array $data, Context $context): ?array;
 }

--- a/Profile/Shopware/Writer/ProductOptionRelationWriter.php
+++ b/Profile/Shopware/Writer/ProductOptionRelationWriter.php
@@ -7,8 +7,6 @@
 
 namespace SwagMigrationAssistant\Profile\Shopware\Writer;
 
-use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use SwagMigrationAssistant\Migration\DataSelection\DefaultEntities;
 use SwagMigrationAssistant\Migration\Writer\AbstractWriter;
 
@@ -17,16 +15,5 @@ class ProductOptionRelationWriter extends AbstractWriter
     public function supports(): string
     {
         return DefaultEntities::PRODUCT_OPTION_RELATION;
-    }
-
-    public function writeData(array $data, Context $context): void
-    {
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($data): void {
-            $this->entityWriter->upsert(
-                $this->definition,
-                $data,
-                WriteContext::createFromContext($context)
-            );
-        });
     }
 }

--- a/Profile/Shopware/Writer/ProductPropertyRelationWriter.php
+++ b/Profile/Shopware/Writer/ProductPropertyRelationWriter.php
@@ -7,8 +7,6 @@
 
 namespace SwagMigrationAssistant\Profile\Shopware\Writer;
 
-use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use SwagMigrationAssistant\Migration\DataSelection\DefaultEntities;
 use SwagMigrationAssistant\Migration\Writer\AbstractWriter;
 
@@ -17,16 +15,5 @@ class ProductPropertyRelationWriter extends AbstractWriter
     public function supports(): string
     {
         return DefaultEntities::PRODUCT_PROPERTY_RELATION;
-    }
-
-    public function writeData(array $data, Context $context): void
-    {
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($data): void {
-            $this->entityWriter->upsert(
-                $this->definition,
-                $data,
-                WriteContext::createFromContext($context)
-            );
-        });
     }
 }

--- a/Test/Migration/Writer/AbstractWriterTest.php
+++ b/Test/Migration/Writer/AbstractWriterTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SwagMigrationAssistant\Test\Migration\Writer;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use SwagMigrationAssistant\Migration\Writer\AbstractWriter;
+
+class AbstractWriterTest extends TestCase
+{
+    /**
+     * @var AbstractWriter
+     */
+    private $abstractWriter;
+
+    /**
+     * @var array
+     */
+    private $dataToWrite;
+
+    /**
+     * @var Context
+     */
+    private $context;
+
+    /**
+     * @var MockObject|EntityWriterInterface
+     */
+    private $entityWriter;
+
+    /**
+     * @var MockObject|EntityDefinition
+     */
+    private $entityDefinition;
+
+    /**
+     * @var array
+     */
+    private $writeResult;
+
+    protected function setUp(): void
+    {
+        $this->entityWriter = $this->createMock(EntityWriterInterface::class);
+        $this->entityDefinition = $this->createMock(EntityDefinition::class);
+        $this->abstractWriter = $this->getMockForAbstractClass(AbstractWriter::class, [
+            $this->entityWriter,
+            $this->entityDefinition,
+        ]);
+        $this->dataToWrite = [];
+        $this->context = Context::createDefaultContext();
+        $this->writeResult = [];
+        $this->entityWriter->method('upsert')->willReturnReference($this->writeResult);
+    }
+
+    public function testWriteDataPassDataToBeWrittenToEntityWriter(): void
+    {
+        $this->dataToWrite = ['test' => '1234'];
+
+        $this->entityWriter
+            ->expects(self::once())
+            ->method('upsert')
+            ->with(
+                $this->entityDefinition,
+                ['test' => '1234'],
+                WriteContext::createFromContext($this->context)
+            );
+
+        $this->abstractWriter->writeData($this->dataToWrite, $this->context);
+    }
+
+    public function testWriteDataReturnWriteResult(): void
+    {
+        $this->writeResult = ['test' => '1234'];
+
+        $result = $this->abstractWriter->writeData($this->dataToWrite, $this->context);
+
+        self::assertEquals(['test' => '1234'], $result);
+    }
+}

--- a/Test/Mock/Migration/Writer/DummyWriter.php
+++ b/Test/Mock/Migration/Writer/DummyWriter.php
@@ -17,7 +17,8 @@ class DummyWriter implements WriterInterface
         return 'dummy';
     }
 
-    public function writeData(array $data, Context $context): void
+    public function writeData(array $data, Context $context): ?array
     {
+        return null;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently there is no way to return the write results in a writer imlementing the `WriterInterface` interface, as its return type is `void`. This is a problem when decorating an existing Writer, like the `ProductWriter`. In this case the decorating class can not use the decorated classes `writeData()` method if it depends on the result of it, but has to re-implement the code of the `AbstractWriter` to allow working with the result of the write operation. Thus when multiple decorator of different plugins exist only one of them might be executed as the decorated instance is never used.

### 2. What does this change do, exactly?

This PR fixes this by adding a return type to the `WriterInterface` interface. The `AbstractWriter` will now return the write result of the upsert operation and can thus be used by decorators relying on the write result.

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.