### PR TITLE
fix: Remove superfluous column select

### DIFF
--- a/Profile/Shopware/Gateway/Local/Reader/AttributeReader.php
+++ b/Profile/Shopware/Gateway/Local/Reader/AttributeReader.php
@@ -81,7 +81,7 @@ abstract class AttributeReader extends AbstractReader
         $columns = $this->cleanupColumns($columns, $foreignKeys);
 
         $query = $this->connection->createQueryBuilder()
-            ->select('config.column_name, config.*')
+            ->select('config.*')
             ->from('s_attribute_configuration', 'config')
             ->where('config.table_name = :table')
             ->setParameter('table', $table)


### PR DESCRIPTION
The additional `config.column_name` lead to not existing `column_name` key in data arrays.

Removing it solved the problem and should have no effects on the migration logic.

Tested with 5.0.0. From Shopware 5.7 to Shopware 6.5.