### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/Profile/Shopware/Gateway/Connection/ConnectionFactory.php
+++ b/Profile/Shopware/Gateway/Connection/ConnectionFactory.php
@@ -60,6 +60,9 @@ class ConnectionFactory implements ConnectionFactoryInterface
             'host' => (string) ($credentials['dbHost'] ?? ''),
             'driver' => 'pdo_mysql',
             'charset' => 'utf8mb4',
+            'driverOptions' => [
+                \PDO::ATTR_STRINGIFY_FETCHES => true,
+            ],
         ];
 
         if (isset($credentials['dbPort'])) {


### PR DESCRIPTION
Since PHP 8.1, the data for a SELECT is no longer returned as PHP strings by default, but now has correct data types such as integer or float.

https://stackoverflow.com/questions/73169064/swag-migration-run-exception-in-logs-while-migrating-from-shopware5-to-shopware6

@mitelg Thanks!