### PR TITLE
Update DefaultEntities.php to fix MIG-274

### DIFF
--- a/Migration/DataSelection/DefaultEntities.php
+++ b/Migration/DataSelection/DefaultEntities.php
@@ -51,9 +51,9 @@ final class DefaultEntities
 
     final public const CROSS_SELLING = 'product_cross_selling';
 
-    final public const CROSS_SELLING_ACCESSORY = 'cross_selling_accessory_item';
+    final public const CROSS_SELLING_ACCESSORY = 'product_cross_selling_accessory';
 
-    final public const CROSS_SELLING_SIMILAR = 'cross_selling_similar_item';
+    final public const CROSS_SELLING_SIMILAR = 'product_cross_selling_similar';
 
     final public const CUSTOMER_WISHLIST = 'customer_wishlist';
 


### PR DESCRIPTION
`CROSS_SELLING_ACCESSORY` and `CROSS_SELLING_SIMILAR` are set to `cross_selling_accessory_item` and `cross_selling_similar_item` and used in CrossSellingConverter.php with `if ($data['type'] === DefaultEntities::CROSS_SELLING_SIMILAR)`  However `$data['type']` is `product_cross_selling_accessory` or `product_cross_selling_similar` so this if query never works.  Therefore the naming has to be changed for it to work. 

This is related to https://issues.shopware.com/issues/MIG-274