### PR TITLE
fix: Make connection optional

### DIFF
--- a/src/Migration/Mapping/SwagMigrationMappingEntity.php
+++ b/src/Migration/Mapping/SwagMigrationMappingEntity.php
@@ -19,7 +19,7 @@ class SwagMigrationMappingEntity extends Entity
 
     protected string $connectionId;
 
-    protected SwagMigrationConnectionEntity $connection;
+    protected ?SwagMigrationConnectionEntity $connection = null;
 
     protected ?string $entity;
 
@@ -43,7 +43,7 @@ class SwagMigrationMappingEntity extends Entity
         $this->connectionId = $connectionId;
     }
 
-    public function getConnection(): SwagMigrationConnectionEntity
+    public function getConnection(): ?SwagMigrationConnectionEntity
     {
         return $this->connection;
     }


### PR DESCRIPTION
if the assocation is not loaded it will otherwise yield a type error:

```
{"errors":[{"status":"500","code":"0","title":"Internal Server Error","detail":"Typed property SwagMigrationAssistant\\Migration\\Mapping\\SwagMigrationMappingEntity::$connection must not be accessed before initialization"}]}
```