### PR TITLE
fix: json_decode with null in mappings caused exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBAL_WITH_NEXT_VERSION
+- MIG-1096 - Fix `json_decode` with `null` run exceptions that occurred with mappings of old migration runs (older assistant versions)
+
 # 14.0.0
 - Moved technical and breaking changes to https://github.com/shopware/SwagMigrationAssistant/blob/trunk/UPGRADE.md
 - MIG-894 - Optimizes the mapping performance for the migration which results in a significantly faster converting step.

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBAL_WITH_NEXT_VERSION
+- MIG-1096 - Beseitigt `json_decode` mit `null` Run Exceptions, die bei Mappings von alten Migrationsläufen auftraten (ältere Assistant-Versionen)
+
 # 14.0.0
 - Technische Änderungen und Breaking-Changes wurden nach https://github.com/shopware/SwagMigrationAssistant/blob/trunk/UPGRADE.md umgezogen
 - MIG-894 - Verbessert die Mapping Performance der Migration, was zu einem deutlich schnelleren Konvertierungsvorgang führt.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -901,11 +901,6 @@ parameters:
 			path: tests/Mock/DummyCollection.php
 
 		-
-			message: "#^Method SwagMigrationAssistant\\\\Test\\\\Mock\\\\DummyThemeService\\:\\:__construct\\(\\) has parameter \\$themeSalesChannelRepository with generic class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityRepository but does not specify its types\\: TEntityCollection$#"
-			count: 1
-			path: tests/Mock/DummyThemeService.php
-
-		-
 			message: "#^Method SwagMigrationAssistant\\\\Test\\\\Mock\\\\Gateway\\\\Dummy\\\\Api\\\\Reader\\\\ApiDummyReader\\:\\:read\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Mock/Gateway/Dummy/Api/Reader/ApiDummyReader.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -71,6 +71,8 @@ parameters:
                 #^Call to deprecated method scope\\(\\) of class Shopware\\\\Core\\\\Framework\\\\Context\\:
                 tag\\:v6\\.7\\.0 \\- reason\\:return\\-type\\-change \\- Return type will be native$#
           """
+        - message: '#^Call to deprecated method(.|\n)+tag:v6\.7\.0#'
+        - message: '#^Instantiation of deprecated class(.|\n)+tag:v6\.7\.0#'
 
 rules:
     # Shopware core rules

--- a/src/Migration/Mapping/MappingService.php
+++ b/src/Migration/Mapping/MappingService.php
@@ -134,7 +134,11 @@ class MappingService implements MappingServiceInterface, ResetInterface
         $mapping['id'] = Uuid::fromBytesToHex($mapping['id']);
         $mapping['connectionId'] = Uuid::fromBytesToHex($mapping['connectionId']);
         $mapping['entityUuid'] = $mapping['entityUuid'] === null ? null : Uuid::fromBytesToHex($mapping['entityUuid']);
-        $mapping['additionalData'] = \json_decode($mapping['additionalData'], true);
+        if (!empty($mapping['additionalData'])) {
+            $mapping['additionalData'] = \json_decode($mapping['additionalData'], true, 512, \JSON_THROW_ON_ERROR);
+        } else {
+            $mapping['additionalData'] = null;
+        }
 
         // PHPStan does not recognize that fetchAssociative returns all required fields. We should move to a Mapping object.
         $mapping['oldIdentifier'] = $mapping['oldIdentifier'] === null ? null : (string) $mapping['oldIdentifier'];

--- a/tests/Migration/Mapping/MappingServiceTest.php
+++ b/tests/Migration/Mapping/MappingServiceTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -293,6 +294,41 @@ class MappingServiceTest extends TestCase
                 }
             }
         }
+    }
+
+    public function testGetMappingWithNullAdditionalData(): void
+    {
+        $entity = DefaultEntities::PRODUCT;
+        $oldIdentifier = '42';
+        $entityUuid = Uuid::randomHex();
+
+        $conn = $this->getContainer()->get(Connection::class);
+        $qb = $conn->createQueryBuilder();
+        $rowsAffected = $qb->insert('swag_migration_mapping')
+            ->values([
+                'id' => ':id',
+                'connection_id' => ':connection_id',
+                'entity' => ':entity',
+                'old_identifier' => ':old_identifier',
+                'entity_uuid' => ':entity_uuid',
+                'created_at' => 'NOW()',
+                // 'additional_data' left with NULL, some older shops might have this data
+            ])
+            ->setParameter('id', Uuid::randomBytes())
+            ->setParameter('connection_id', Uuid::fromHexToBytes($this->connectionId))
+            ->setParameter('entity', $entity)
+            ->setParameter('old_identifier', $oldIdentifier)
+            ->setParameter('entity_uuid', Uuid::fromHexToBytes($entityUuid))
+        ->executeStatement();
+        static::assertSame(1, $rowsAffected);
+
+        // This call shouldn't throw TypeError: json_decode(): Argument #1 ($json) must be of type string, null given
+        $retrievedMapping = $this->mappingService->getMapping($this->connectionId, $entity, $oldIdentifier, Context::createDefaultContext());
+
+        static::assertArrayHasKey('entityUuid', $retrievedMapping);
+        static::assertSame($entityUuid, $retrievedMapping['entityUuid']);
+        static::assertArrayHasKey('additionalData', $retrievedMapping);
+        static::assertSame(null, $retrievedMapping['additionalData']);
     }
 
     /**

--- a/tests/Migration/Mapping/MappingServiceTest.php
+++ b/tests/Migration/Mapping/MappingServiceTest.php
@@ -324,6 +324,7 @@ class MappingServiceTest extends TestCase
         // This call shouldn't throw TypeError: json_decode(): Argument #1 ($json) must be of type string, null given
         $retrievedMapping = $this->mappingService->getMapping($this->connectionId, $entity, $oldIdentifier, Context::createDefaultContext());
 
+        static::assertNotNull($retrievedMapping);
         static::assertArrayHasKey('entityUuid', $retrievedMapping);
         static::assertSame($entityUuid, $retrievedMapping['entityUuid']);
         static::assertArrayHasKey('additionalData', $retrievedMapping);

--- a/tests/Migration/Mapping/MappingServiceTest.php
+++ b/tests/Migration/Mapping/MappingServiceTest.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
-use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -328,7 +327,7 @@ class MappingServiceTest extends TestCase
         static::assertArrayHasKey('entityUuid', $retrievedMapping);
         static::assertSame($entityUuid, $retrievedMapping['entityUuid']);
         static::assertArrayHasKey('additionalData', $retrievedMapping);
-        static::assertSame(null, $retrievedMapping['additionalData']);
+        static::assertNull($retrievedMapping['additionalData']);
     }
 
     /**

--- a/tests/Mock/DummyThemeService.php
+++ b/tests/Mock/DummyThemeService.php
@@ -8,6 +8,8 @@
 namespace SwagMigrationAssistant\Test\Mock;
 
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\ThemeService;
@@ -15,6 +17,9 @@ use Shopware\Storefront\Theme\ThemeService;
 #[Package('fundamentals@after-sales')]
 class DummyThemeService extends ThemeService
 {
+    /**
+     * @param EntityRepository<EntityCollection<Entity>> $themeSalesChannelRepository
+     */
     public function __construct(private readonly EntityRepository $themeSalesChannelRepository)
     {
     }


### PR DESCRIPTION
when the mapping table contained data from very old migration-assistant versions

fixes MIG-1096