### PR TITLE
fix: undefined array key salesChannelId exceptions in SW6->SW6

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,8 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          bootstrap="tests/TestBootstrap.php"
          executionOrder="random"
-         cacheDirectory="var/cache/.phpunit.cache">
+         cacheDirectory="var/cache/.phpunit.cache"
+         displayDetailsOnTestsThatTriggerWarnings="true">
     <coverage/>
 
     <php>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,8 @@
          bootstrap="tests/TestBootstrap.php"
          executionOrder="random"
          cacheDirectory="var/cache/.phpunit.cache"
-         displayDetailsOnTestsThatTriggerWarnings="true">
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnWarning="true">
     <coverage/>
 
     <php>

--- a/src/Migration/Media/MediaFileService.php
+++ b/src/Migration/Media/MediaFileService.php
@@ -89,6 +89,7 @@ class MediaFileService implements MediaFileServiceInterface, ResetInterface
         foreach ($converted as $dataId => $entity) {
             if (!isset($updateWrittenData[$dataId])) {
                 unset($converted[$dataId]);
+                continue;
             }
 
             if ($updateWrittenData[$dataId]['written'] === true) {

--- a/src/Profile/Shopware6/Converter/PageSystemConfigConverter.php
+++ b/src/Profile/Shopware6/Converter/PageSystemConfigConverter.php
@@ -38,7 +38,7 @@ class PageSystemConfigConverter extends ShopwareConverter
     {
         $converted = $data;
 
-        $systemConfigUuid = $this->systemConfigLookup->get($data['configurationKey'], $data['salesChannelId'], $this->context);
+        $systemConfigUuid = $this->systemConfigLookup->get($data['configurationKey'], $data['salesChannelId'] ?? null, $this->context);
         if ($systemConfigUuid !== null) {
             $converted['id'] = $systemConfigUuid;
         }

--- a/src/Profile/Shopware6/Converter/SeoUrlTemplateConverter.php
+++ b/src/Profile/Shopware6/Converter/SeoUrlTemplateConverter.php
@@ -39,7 +39,7 @@ class SeoUrlTemplateConverter extends ShopwareConverter
         $converted = $data;
 
         $seoUrlTemplateUuid = $this->seoUrlTemplateLookup->get(
-            $data['salesChannelId'],
+            $data['salesChannelId'] ?? null,
             $data['routeName'],
             $this->context
         );

--- a/src/Profile/Shopware6/Converter/SystemConfigConverter.php
+++ b/src/Profile/Shopware6/Converter/SystemConfigConverter.php
@@ -38,7 +38,7 @@ class SystemConfigConverter extends ShopwareConverter
     {
         $converted = $data;
 
-        $systemConfigUuid = $this->systemConfigLookup->get($data['configurationKey'], $data['salesChannelId'], $this->context);
+        $systemConfigUuid = $this->systemConfigLookup->get($data['configurationKey'], $data['salesChannelId'] ?? null, $this->context);
         if ($systemConfigUuid !== null) {
             $converted['id'] = $systemConfigUuid;
         }

--- a/tests/Profile/Shopware6/Converter/DocumentBaseConfigConverterTest.php
+++ b/tests/Profile/Shopware6/Converter/DocumentBaseConfigConverterTest.php
@@ -34,7 +34,7 @@ class DocumentBaseConfigConverterTest extends ShopwareConverterTest
         static::assertIsArray($mappingArray);
 
         foreach ($mappingArray as $mapping) {
-            if ($mapping['entity'] !== DefaultEntities::ORDER_DOCUMENT_TYPE) {
+            if ($mapping['entityName'] === DefaultEntities::ORDER_DOCUMENT_TYPE) {
                 $documentLookup->method('get')->willReturn($mapping['newIdentifier']);
             }
 

--- a/tests/_fixtures/Shopware6/PageSystemConfig/02-AlreadyExists/mapping.php
+++ b/tests/_fixtures/Shopware6/PageSystemConfig/02-AlreadyExists/mapping.php
@@ -11,7 +11,7 @@ return [
     [
         'entityName' => DefaultEntities::SYSTEM_CONFIG,
         'oldIdentifier' => 'a4b495f06c1e49279dea600ffea12794',
-        'newIdentifier' => '91f23b8a27c845c39ce4a2ea1187b3b9',
+        'newIdentifier' => '91f23b8a27c845c39ce4a2ea1187b3b1',
     ],
     [
         'entityName' => DefaultEntities::SALES_CHANNEL,

--- a/tests/_fixtures/Shopware6/PageSystemConfig/02-AlreadyExists/output.php
+++ b/tests/_fixtures/Shopware6/PageSystemConfig/02-AlreadyExists/output.php
@@ -9,5 +9,5 @@ return [
     'configurationKey' => 'core.basicInformation.contactPage',
     'configurationValue' => 'b0dfd6d77eea4cbaa02b35e8562d823d',
     'salesChannelId' => '91f23b8a27c845c39ce4a2ea1187b3b9',
-    'id' => '91f23b8a27c845c39ce4a2ea1187b3b9',
+    'id' => '91f23b8a27c845c39ce4a2ea1187b3b1',
 ];

--- a/tests/_fixtures/Shopware6/SystemConfig/02-AlreadyExists/mapping.php
+++ b/tests/_fixtures/Shopware6/SystemConfig/02-AlreadyExists/mapping.php
@@ -11,7 +11,7 @@ return [
     [
         'entityName' => DefaultEntities::SYSTEM_CONFIG,
         'oldIdentifier' => '2fdf49fd31384c7baff4d36797b08681',
-        'newIdentifier' => '91f23b8a27c845c39ce4a2ea1187b3b9',
+        'newIdentifier' => '91f23b8a27c845c39ce4a2ea1187b3b1',
     ],
     [
         'entityName' => DefaultEntities::SALES_CHANNEL,

--- a/tests/_fixtures/Shopware6/SystemConfig/02-AlreadyExists/output.php
+++ b/tests/_fixtures/Shopware6/SystemConfig/02-AlreadyExists/output.php
@@ -6,7 +6,7 @@
  */
 
 return [
-    'id' => '91f23b8a27c845c39ce4a2ea1187b3b9',
+    'id' => '91f23b8a27c845c39ce4a2ea1187b3b1',
     'configurationKey' => 'core.cart.maxQuantity',
     'configurationValue' => '100',
     'salesChannelId' => '91f23b8a27c845c39ce4a2ea1187b3b9',


### PR DESCRIPTION
closes MIG-1099

It also does:
- PHPUnit will now emit all PHP warnings in it's output
- PHPUnit will now fail if any PHP warnings were triggered, this also fails the CI job
- Fix all PHP warnings uncovered by tests