### PR TITLE
fix: tagged argument deprecation warnings

### DIFF
--- a/src/DependencyInjection/dataProvider.xml
+++ b/src/DependencyInjection/dataProvider.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="SwagMigrationAssistant\DataProvider\Provider\ProviderRegistry">
-            <argument type="tagged" tag="shopware.dataProvider.provider"/>
+            <argument type="tagged_iterator" tag="shopware.dataProvider.provider"/>
         </service>
 
         <service id="SwagMigrationAssistant\Controller\DataProviderController" public="true">

--- a/src/DependencyInjection/gateway.xml
+++ b/src/DependencyInjection/gateway.xml
@@ -6,7 +6,7 @@
 
     <services>
         <service id="SwagMigrationAssistant\Migration\Gateway\GatewayRegistry">
-            <argument type="tagged" tag="shopware.migration.gateway"/>
+            <argument type="tagged_iterator" tag="shopware.migration.gateway"/>
         </service>
     </services>
 </container>

--- a/src/DependencyInjection/migration.xml
+++ b/src/DependencyInjection/migration.xml
@@ -27,7 +27,7 @@
         </service>
 
         <service id="SwagMigrationAssistant\Migration\Converter\ConverterRegistry">
-            <argument type="tagged" tag="shopware.migration.converter"/>
+            <argument type="tagged_iterator" tag="shopware.migration.converter"/>
         </service>
 
         <service id="SwagMigrationAssistant\Migration\MigrationContextFactory">
@@ -212,7 +212,7 @@
         </service>
 
         <service id="SwagMigrationAssistant\Migration\Gateway\Reader\ReaderRegistry">
-            <argument type="tagged" tag="shopware.migration.reader"/>
+            <argument type="tagged_iterator" tag="shopware.migration.reader"/>
         </service>
 
         <service id="SwagMigrationAssistant\Migration\Service\MigrationDataConverter" public="true">
@@ -242,7 +242,7 @@
         </service>
 
         <service id="SwagMigrationAssistant\Migration\Media\MediaFileProcessorRegistry">
-            <argument type="tagged" tag="shopware.migration.media_file_processor"/>
+            <argument type="tagged_iterator" tag="shopware.migration.media_file_processor"/>
         </service>
 
         <service id="SwagMigrationAssistant\Migration\Media\Processor\HttpDownloadServiceBase" abstract="true">
@@ -300,15 +300,15 @@
         </service>
 
         <service id="SwagMigrationAssistant\Migration\DataSelection\DataSelectionRegistry">
-            <argument type="tagged" tag="shopware.migration.data_selection"/>
+            <argument type="tagged_iterator" tag="shopware.migration.data_selection"/>
         </service>
 
         <service id="SwagMigrationAssistant\Migration\DataSelection\DataSet\DataSetRegistry">
-            <argument type="tagged" tag="shopware.migration.data_set"/>
+            <argument type="tagged_iterator" tag="shopware.migration.data_set"/>
         </service>
 
         <service id="SwagMigrationAssistant\Migration\Premapping\PremappingReaderRegistry">
-            <argument type="tagged" tag="shopware.migration.pre_mapping_reader"/>
+            <argument type="tagged_iterator" tag="shopware.migration.pre_mapping_reader"/>
         </service>
 
         <service id="SwagMigrationAssistant\Migration\Service\PremappingService">
@@ -353,7 +353,7 @@
         </service>
 
         <service id="SwagMigrationAssistant\Migration\MessageQueue\Handler\MigrationProcessorRegistry">
-            <argument type="tagged" tag="shopware.migration.processor"/>
+            <argument type="tagged_iterator" tag="shopware.migration.processor"/>
         </service>
 
         <service id="SwagMigrationAssistant\Migration\MessageQueue\Handler\Processor\AbstractProcessor" abstract="true">

--- a/src/DependencyInjection/profile.xml
+++ b/src/DependencyInjection/profile.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="SwagMigrationAssistant\Migration\Profile\ProfileRegistry"
                  class="SwagMigrationAssistant\Migration\Profile\ProfileRegistry">
-            <argument type="tagged" tag="shopware.migration.profile"/>
+            <argument type="tagged_iterator" tag="shopware.migration.profile"/>
         </service>
     </services>
 </container>

--- a/src/DependencyInjection/shopware.xml
+++ b/src/DependencyInjection/shopware.xml
@@ -42,7 +42,7 @@
             <argument type="service" id="swag_migration_media_file.repository"/>
             <argument type="service" id="Shopware\Core\Content\Media\File\FileSaver"/>
             <argument type="service" id="SwagMigrationAssistant\Migration\Logging\LoggingService"/>
-            <argument type="tagged" tag="shopware.migration.media_strategy_resolver"/>
+            <argument type="tagged_iterator" tag="shopware.migration.media_strategy_resolver"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <tag name="shopware.migration.media_file_processor"/>
         </service>

--- a/src/DependencyInjection/writer.xml
+++ b/src/DependencyInjection/writer.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="SwagMigrationAssistant\Migration\Writer\WriterRegistry"
                  class="SwagMigrationAssistant\Migration\Writer\WriterRegistry">
-            <argument type="tagged" tag="shopware.migration.writer"/>
+            <argument type="tagged_iterator" tag="shopware.migration.writer"/>
         </service>
 
         <service id="SwagMigrationAssistant\Migration\Writer\AbstractWriter" abstract="true"/>


### PR DESCRIPTION
Showed up while running **platform** `composer run phpunit` tests (even if plugin is not installed).
![image](https://github.com/user-attachments/assets/8a39bf9e-77c9-4598-9d0e-c9d5aef8e20c)
