### PR TITLE
fix: snippet calls with wrong argument order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# NEXT-RELEASE
+- Fixed translations of error groups missing details like the entity
+
 # 15.0.2
 - Fixed data selection tab freezing due to infinite loop in SW6.7RC4 or later
 - Fixed connections names containing hyphens causing errors for custom field migration

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# NEXT-RELEASE
+- Übersetzungen von Fehlergruppen behoben, welche Details wie den Entitätsnamen nicht darstellten
+ 
 # 15.0.2
 - Einfrieren des Browsers im Datenauswahl-Tab aufgrund einer Endlosschleife ab SW6.7RC4 behoben
 - Verbindungsnamen mit Bindestrichen, die Fehler bei der Migration benutzerdefinierter Felder verursachen, wurden behoben

--- a/src/Resources/app/administration/src/module/swag-migration/page/swag-migration-data-selector/swag-migration-data-selector.html.twig
+++ b/src/Resources/app/administration/src/module/swag-migration/page/swag-migration-data-selector/swag-migration-data-selector.html.twig
@@ -7,7 +7,7 @@
                           :key="warning.snippetKey"
                           class="swag-migration-data-selector__warning"
                           variant="attention">
-                    {{ $tc(warning.snippetKey, warning.pluralizationCount, warning.snippetArguments) }}
+                    {{ $tc(warning.snippetKey, warning.snippetArguments, warning.pluralizationCount) }}
                 </mt-banner>
             </div>
         {% endblock %}

--- a/src/Resources/app/administration/src/module/swag-migration/page/swag-migration-history-detail-errors/index.js
+++ b/src/Resources/app/administration/src/module/swag-migration/page/swag-migration-history-detail-errors/index.js
@@ -105,7 +105,7 @@ Component.register('swag-migration-history-detail-errors', {
                 this.total = response.total;
                 this.allMigrationErrors = response.items;
                 this.allMigrationErrors.forEach((item) => {
-                    item.title = this.$tc(this.getErrorTitleSnippet(item), 0, { entity: item.entity });
+                    item.title = this.$tc(this.getErrorTitleSnippet(item), { entity: item.entity }, 0);
                 });
                 this.downloadUrl = response.downloadUrl;
                 return this.allMigrationErrors;

--- a/src/Resources/app/administration/src/module/swag-migration/page/swag-migration-main-page/swag-migration-main-page.html.twig
+++ b/src/Resources/app/administration/src/module/swag-migration/page/swag-migration-main-page/swag-migration-main-page.html.twig
@@ -15,7 +15,7 @@
                                 class="swag-migration-index-main-page__warning"
                                 variant="attention"
                             >
-                                {{ $tc(warning.snippetKey, warning.pluralizationCount, warning.snippetArguments) }}
+                                {{ $tc(warning.snippetKey, warning.snippetArguments, warning.pluralizationCount) }}
                             </mt-banner>
                         </template>
                     </div>


### PR DESCRIPTION
## Before
![Screenshot 2025-05-26 at 13 28 30](https://github.com/user-attachments/assets/3d5927f5-4198-4493-a2f1-d3a0b00f41fc)

## After
![Screenshot 2025-05-26 at 13 26 20](https://github.com/user-attachments/assets/139b71ba-4d14-43d6-9dac-31e40dce767c)
