### PR TITLE
fix: customer migration from shopware 6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 15.0.3
 - Fixed translations of error groups missing details like the entity
-- Fixed handling of customers without default payment method in Shopware 6.7
+- Fixed handling of customers without default payment method in SW6.7 migrations
 
 # 15.0.2
 - Fixed data selection tab freezing due to infinite loop in SW6.7RC4 or later

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# NEXT-RELEASE
+# 15.0.3
 - Fixed translations of error groups missing details like the entity
+- Fixed handling of customers without default payment method in Shopware 6.7
 
 # 15.0.2
 - Fixed data selection tab freezing due to infinite loop in SW6.7RC4 or later

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,6 @@
 # 15.0.3
 - Übersetzungen von Fehlergruppen behoben, welche Details wie den Entitätsnamen nicht darstellten
-- Behandlung von Kunden ohne Standardzahlungsmethode in Shopware 6.7 behoben 
+- Fehler bei Kunden ohne Standardzahlungsmethode in SW6.7 Migrationen behoben
 
 # 15.0.2
 - Einfrieren des Browsers im Datenauswahl-Tab aufgrund einer Endlosschleife ab SW6.7RC4 behoben

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,7 @@
-# NEXT-RELEASE
+# 15.0.3
 - Übersetzungen von Fehlergruppen behoben, welche Details wie den Entitätsnamen nicht darstellten
- 
+- Behandlung von Kunden ohne Standardzahlungsmethode in Shopware 6.7 behoben 
+
 # 15.0.2
 - Einfrieren des Browsers im Datenauswahl-Tab aufgrund einer Endlosschleife ab SW6.7RC4 behoben
 - Verbindungsnamen mit Bindestrichen, die Fehler bei der Migration benutzerdefinierter Felder verursachen, wurden behoben

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/migration-assistant",
     "description": "Migration plugin for shopware/platform",
-    "version": "15.0.2",
+    "version": "15.0.3",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/Profile/Shopware6/Converter/CustomerConverter.php
+++ b/src/Profile/Shopware6/Converter/CustomerConverter.php
@@ -37,7 +37,10 @@ class CustomerConverter extends ShopwareConverter
             $converted['lastPaymentMethodId'] = $this->getMappingIdFacade(DefaultEntities::PAYMENT_METHOD, $converted['lastPaymentMethodId']);
         }
 
-        $converted['defaultPaymentMethodId'] = $this->getMappingIdFacade(DefaultEntities::PAYMENT_METHOD, $converted['defaultPaymentMethodId']);
+        if (isset($converted['defaultPaymentMethodId'])) {
+            $converted['defaultPaymentMethodId'] = $this->getMappingIdFacade(DefaultEntities::PAYMENT_METHOD, $converted['defaultPaymentMethodId']);
+        }
+
         $converted['salutationId'] = $this->getMappingIdFacade(DefaultEntities::SALUTATION, $converted['salutationId']);
         $converted['languageId'] = $this->getMappingIdFacade(DefaultEntities::LANGUAGE, $converted['languageId']);
 

--- a/tests/_fixtures/Shopware6/Customer/03-WithoutDefaultPaymentMethod/input.php
+++ b/tests/_fixtures/Shopware6/Customer/03-WithoutDefaultPaymentMethod/input.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    'id' => '54c4e247509f44d183e2ef48c012f3c3',
+    'groupId' => 'cfbd5018d38d41d8adca10d94fc8bdd6',
+    'defaultPaymentMethodId' => null,
+    'lastPaymentMethodId' => null,
+    'salesChannelId' => '98432def39fc4624b33213a56b8c944d',
+    'languageId' => '2fbb5fe2e29a4d70aa5854ce7ce3e20b',
+    'defaultBillingAddressId' => '515f8a37357748dcac9faf7bb75b06fc',
+    'defaultShippingAddressId' => '4b036b2bd72145d7b29ecf471db653f4',
+    'customerNumber' => '10037',
+    'salutationId' => '9c8d449d0e474250bbcaac193b92f04d',
+    'firstName' => 'Dorian',
+    'lastName' => 'Bayer',
+    'password' => '$2y$10$xGVchdjb5e54CzyvGjLWVeVOw/r.DXvFrgU5xLcKGykV13n0AEF9i',
+    'email' => '54c4e247509f44d183e2ef48c012f3c3madelyn94@example.org',
+    'title' => 'Dr.',
+    'active' => true,
+    'doubleOptInRegistration' => false,
+    'guest' => false,
+    'newsletter' => false,
+    'orderCount' => 0,
+    'createdById' => '019270226a5a702db3c95acbbddd9bd1',
+    'updatedById' => '019270226a5a702db3c95acbbddd9bd2',
+    'addresses' => [
+        [
+            'countryId' => '6f7bb25afa8348a1899df4338fb487c2',
+            'salutationId' => '9c8d449d0e474250bbcaac193b92f04d',
+            'firstName' => 'Dorian',
+            'lastName' => 'Bayer',
+            'zipcode' => '31336-4456',
+            'city' => 'Wizaview',
+            'title' => 'Dr.',
+            'street' => 'Nikolaus Trace',
+            'id' => '4b036b2bd72145d7b29ecf471db653f4',
+        ],
+        [
+            'countryId' => '33938084f8b248bab568210b66874837',
+            'salutationId' => '9c8d449d0e474250bbcaac193b92f04d',
+            'firstName' => 'Dorian',
+            'lastName' => 'Bayer',
+            'zipcode' => '93621',
+            'city' => 'Swiftville',
+            'title' => 'Dr.',
+            'street' => 'Zola Burg',
+            'id' => '515f8a37357748dcac9faf7bb75b06fc',
+        ],
+        [
+            'countryStateId' => '92fa111b3a81433fb22fd17d3d6804fc',
+            'countryId' => 'b218059fad4d4a79a58906fbc47f705a',
+            'salutationId' => '9c8d449d0e474250bbcaac193b92f04d',
+            'firstName' => 'Dorian',
+            'lastName' => 'Bayer',
+            'zipcode' => '74033',
+            'city' => 'Lake Jarrettown',
+            'title' => 'Dr.',
+            'street' => 'Marcel Path',
+            'id' => 'ded113f89c4549e59f82299f2ceb2ad0',
+        ],
+    ],
+];

--- a/tests/_fixtures/Shopware6/Customer/03-WithoutDefaultPaymentMethod/mapping.php
+++ b/tests/_fixtures/Shopware6/Customer/03-WithoutDefaultPaymentMethod/mapping.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use SwagMigrationAssistant\Migration\DataSelection\DefaultEntities;
+
+return [
+    [
+        'entityName' => DefaultEntities::LANGUAGE,
+        'oldIdentifier' => '2fbb5fe2e29a4d70aa5854ce7ce3e20b',
+        'newIdentifier' => '41248655c60c4dd58cde43f14cd4f149',
+    ],
+    [
+        'entityName' => DefaultEntities::SALUTATION,
+        'oldIdentifier' => '9c8d449d0e474250bbcaac193b92f04d',
+        'newIdentifier' => '88248655c60c4dd58cde43f14cd4f149',
+    ],
+    [
+        'entityName' => DefaultEntities::COUNTRY,
+        'oldIdentifier' => '6f7bb25afa8348a1899df4338fb487c2',
+        'newIdentifier' => '8f7bb25afa8348a1899df4338fb487c2',
+    ],
+    [
+        'entityName' => DefaultEntities::COUNTRY,
+        'oldIdentifier' => '33938084f8b248bab568210b66874837',
+        'newIdentifier' => '427bb25afa8348a1899df4338fb487c2',
+    ],
+    [
+        'entityName' => DefaultEntities::COUNTRY,
+        'oldIdentifier' => 'b218059fad4d4a79a58906fbc47f705a',
+        'newIdentifier' => 'ac18059fad4d4a79a58906fbc47f705a',
+    ],
+    [
+        'entityName' => DefaultEntities::COUNTRY_STATE,
+        'oldIdentifier' => '92fa111b3a81433fb22fd17d3d6804fc',
+        'newIdentifier' => '427bb25afa8348a1899df4338fb487c2',
+    ],
+    [
+        'entityName' => DefaultEntities::USER,
+        'oldIdentifier' => '019270226a5a702db3c95acbbddd9bd1',
+        'newIdentifier' => '019270bb17fe70158f37ac83eaa7f761',
+    ],
+    [
+        'entityName' => DefaultEntities::USER,
+        'oldIdentifier' => '019270226a5a702db3c95acbbddd9bd2',
+        'newIdentifier' => '019270bb17fe70158f37ac83eaa7f762',
+    ],
+];

--- a/tests/_fixtures/Shopware6/Customer/03-WithoutDefaultPaymentMethod/output.php
+++ b/tests/_fixtures/Shopware6/Customer/03-WithoutDefaultPaymentMethod/output.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    'id' => '54c4e247509f44d183e2ef48c012f3c3',
+    'groupId' => 'cfbd5018d38d41d8adca10d94fc8bdd6',
+    'defaultPaymentMethodId' => null,
+    'lastPaymentMethodId' => null,
+    'salesChannelId' => '98432def39fc4624b33213a56b8c944d',
+    'languageId' => '41248655c60c4dd58cde43f14cd4f149',
+    'defaultBillingAddressId' => '515f8a37357748dcac9faf7bb75b06fc',
+    'defaultShippingAddressId' => '4b036b2bd72145d7b29ecf471db653f4',
+    'customerNumber' => '10037',
+    'salutationId' => '88248655c60c4dd58cde43f14cd4f149',
+    'firstName' => 'Dorian',
+    'lastName' => 'Bayer',
+    'password' => '$2y$10$xGVchdjb5e54CzyvGjLWVeVOw/r.DXvFrgU5xLcKGykV13n0AEF9i',
+    'email' => '54c4e247509f44d183e2ef48c012f3c3madelyn94@example.org',
+    'title' => 'Dr.',
+    'active' => true,
+    'doubleOptInRegistration' => false,
+    'guest' => false,
+    'newsletter' => false,
+    'orderCount' => 0,
+    'createdById' => '019270bb17fe70158f37ac83eaa7f761',
+    'updatedById' => '019270bb17fe70158f37ac83eaa7f762',
+    'addresses' => [
+        [
+            'countryId' => '8f7bb25afa8348a1899df4338fb487c2',
+            'salutationId' => '88248655c60c4dd58cde43f14cd4f149',
+            'firstName' => 'Dorian',
+            'lastName' => 'Bayer',
+            'zipcode' => '31336-4456',
+            'city' => 'Wizaview',
+            'title' => 'Dr.',
+            'street' => 'Nikolaus Trace',
+            'id' => '4b036b2bd72145d7b29ecf471db653f4',
+        ],
+        [
+            'countryId' => '427bb25afa8348a1899df4338fb487c2',
+            'salutationId' => '88248655c60c4dd58cde43f14cd4f149',
+            'firstName' => 'Dorian',
+            'lastName' => 'Bayer',
+            'zipcode' => '93621',
+            'city' => 'Swiftville',
+            'title' => 'Dr.',
+            'street' => 'Zola Burg',
+            'id' => '515f8a37357748dcac9faf7bb75b06fc',
+        ],
+        [
+            'countryStateId' => '427bb25afa8348a1899df4338fb487c2',
+            'countryId' => 'ac18059fad4d4a79a58906fbc47f705a',
+            'salutationId' => '88248655c60c4dd58cde43f14cd4f149',
+            'firstName' => 'Dorian',
+            'lastName' => 'Bayer',
+            'zipcode' => '74033',
+            'city' => 'Lake Jarrettown',
+            'title' => 'Dr.',
+            'street' => 'Marcel Path',
+            'id' => 'ded113f89c4549e59f82299f2ceb2ad0',
+        ],
+    ],
+];


### PR DESCRIPTION
fixes: [#10796](https://github.com/shopware/shopware/issues/10796)

`defaultPaymentMethodId` can be null in 6.7