### PR TITLE
fix: adjust profile icon paths

### DIFF
--- a/src/Profile/Shopware54/Shopware54Profile.php
+++ b/src/Profile/Shopware54/Shopware54Profile.php
@@ -21,7 +21,7 @@ class Shopware54Profile implements ShopwareProfileInterface
 
     final public const AUTHOR_NAME = 'shopware AG';
 
-    final public const ICON_PATH = '/swagmigrationassistant/static/img/migration-assistant-plugin.svg';
+    final public const ICON_PATH = '/swagmigrationassistant/administration/static/img/migration-assistant-plugin.svg';
 
     public function getName(): string
     {

--- a/src/Profile/Shopware55/Shopware55Profile.php
+++ b/src/Profile/Shopware55/Shopware55Profile.php
@@ -21,7 +21,7 @@ class Shopware55Profile implements ShopwareProfileInterface
 
     final public const AUTHOR_NAME = 'shopware AG';
 
-    final public const ICON_PATH = '/swagmigrationassistant/static/img/migration-assistant-plugin.svg';
+    final public const ICON_PATH = '/swagmigrationassistant/administration/static/img/migration-assistant-plugin.svg';
 
     public function getName(): string
     {

--- a/src/Profile/Shopware56/Shopware56Profile.php
+++ b/src/Profile/Shopware56/Shopware56Profile.php
@@ -21,7 +21,7 @@ class Shopware56Profile implements ShopwareProfileInterface
 
     final public const AUTHOR_NAME = 'shopware AG';
 
-    final public const ICON_PATH = '/swagmigrationassistant/static/img/migration-assistant-plugin.svg';
+    final public const ICON_PATH = '/swagmigrationassistant/administration/static/img/migration-assistant-plugin.svg';
 
     public function getName(): string
     {

--- a/src/Profile/Shopware57/Shopware57Profile.php
+++ b/src/Profile/Shopware57/Shopware57Profile.php
@@ -21,7 +21,7 @@ class Shopware57Profile implements ShopwareProfileInterface
 
     final public const AUTHOR_NAME = 'shopware AG';
 
-    final public const ICON_PATH = '/swagmigrationassistant/static/img/migration-assistant-plugin.svg';
+    final public const ICON_PATH = '/swagmigrationassistant/administration/static/img/migration-assistant-plugin.svg';
 
     public function getName(): string
     {

--- a/src/Profile/Shopware6/Shopware6MajorProfile.php
+++ b/src/Profile/Shopware6/Shopware6MajorProfile.php
@@ -18,7 +18,7 @@ class Shopware6MajorProfile implements Shopware6ProfileInterface
 
     final public const AUTHOR_NAME = 'shopware AG';
 
-    final public const ICON_PATH = '/swagmigrationassistant/static/img/migration-assistant-plugin.svg';
+    final public const ICON_PATH = '/swagmigrationassistant/administration/static/img/migration-assistant-plugin.svg';
 
     private string $supportedVersion;
 


### PR DESCRIPTION
Noticed the missing profile icon while reviewing other changes. I guess this is a follow-up to #28?

<img width="969" height="231" alt="image" src="https://github.com/user-attachments/assets/6e05767a-3dfa-4780-9007-8bfb0e1cf6e8" />

<img width="968" height="230" alt="image" src="https://github.com/user-attachments/assets/1bf4e39d-7cfe-4d22-9f73-4499a23e4519" />
