### PR TITLE
fix: typos in error resolution "no option available" banner

### DIFF
--- a/src/Resources/app/administration/src/module/swag-migration/snippet/en.json
+++ b/src/Resources/app/administration/src/module/swag-migration/snippet/en.json
@@ -591,7 +591,7 @@
               "title": "Edit: {count} Items",
               "banner": {
                 "title": "No option available",
-                "content": "Please create atleast one option to select in the corresponding Admnistration area.",
+                "content": "Please create at least one option to select in the corresponding Administration area.",
                 "link": "Add an Option"
               },
               "unhandledBanner": {


### PR DESCRIPTION
`atleast` → `at least`

`Admnistration` → `Administration`

<img width="499" height="142" alt="Screen Shot 2025-12-09 at 13 22 10" src="https://github.com/user-attachments/assets/02836150-9745-4b3c-be2d-0fed5f24b3f9" />
