### PR TITLE
fix: populate primaryOrderDeliveryId and primaryOrderTransactionId in OrderConverter

### DIFF
--- a/src/Profile/Shopware/Converter/OrderConverter.php
+++ b/src/Profile/Shopware/Converter/OrderConverter.php
@@ -321,6 +321,13 @@ abstract class OrderConverter extends ShopwareConverter
         $this->applyTransactions($data, $converted);
         unset($data['cleared'], $data['paymentstatus']);
 
+        if (!empty($converted['deliveries'])) {
+            $converted['primaryOrderDeliveryId'] = $converted['deliveries'][0]['id'];
+        }
+        if (!empty($converted['transactions'])) {
+            $converted['primaryOrderTransactionId'] = $converted['transactions'][0]['id'];
+        }
+
         $billingAddress = $this->getAddress($data['billingaddress']);
         if (empty($billingAddress)) {
             $this->loggingService->addLogEntry(new EmptyNecessaryFieldRunLog(

--- a/src/Profile/Shopware6/Converter/OrderConverter.php
+++ b/src/Profile/Shopware6/Converter/OrderConverter.php
@@ -161,6 +161,13 @@ class OrderConverter extends ShopwareConverter
             $converted['updatedById'] = $this->getMappingIdFacade(DefaultEntities::USER, $data['updatedById']);
         }
 
+        if (!isset($converted['primaryOrderDeliveryId']) && !empty($converted['deliveries'])) {
+            $converted['primaryOrderDeliveryId'] = $converted['deliveries'][0]['id'];
+        }
+        if (!isset($converted['primaryOrderTransactionId']) && !empty($converted['transactions'])) {
+            $converted['primaryOrderTransactionId'] = $converted['transactions'][0]['id'];
+        }
+
         return new ConvertStruct($converted, null, $this->mainMapping['id'] ?? null);
     }
 

--- a/src/Profile/Shopware6/Converter/ShopwareConverter.php
+++ b/src/Profile/Shopware6/Converter/ShopwareConverter.php
@@ -65,7 +65,7 @@ abstract class ShopwareConverter extends Converter
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param array<array-key, mixed> $data
      */
     abstract protected function convertData(array $data): ConvertStruct;
 
@@ -129,7 +129,7 @@ abstract class ShopwareConverter extends Converter
     /**
      * Replaces every id (associationIdKey) in the specified array of entities with the right mapping dependent one.
      *
-     * @param array<string, mixed> $associationArray
+     * @param array<array-key, mixed> $associationArray
      */
     protected function updateAssociationIds(array &$associationArray, string $entity, string $associationIdKey, string $sourceEntity, bool $logMissing = true, bool $unsetMissing = false): void
     {

--- a/tests/Profile/Shopware55/Converter/OrderConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/OrderConverterTest.php
@@ -194,6 +194,13 @@ class OrderConverterTest extends TestCase
         static::assertArrayHasKey('id', $converted);
         static::assertArrayHasKey('orderCustomer', $converted);
         static::assertArrayHasKey('deliveries', $converted);
+        static::assertArrayHasKey('transactions', $converted);
+        static::assertNotEmpty($converted['deliveries']);
+        static::assertNotEmpty($converted['transactions']);
+        static::assertArrayHasKey('primaryOrderDeliveryId', $converted);
+        static::assertArrayHasKey('primaryOrderTransactionId', $converted);
+        static::assertSame($converted['deliveries'][0]['id'], $converted['primaryOrderDeliveryId']);
+        static::assertSame($converted['transactions'][0]['id'], $converted['primaryOrderTransactionId']);
         static::assertSame(TestDefaults::SALES_CHANNEL, $converted['salesChannelId']);
         static::assertSame('test@example.com', $converted['orderCustomer']['email']);
         static::assertCount(0, $this->loggingService->getLoggingArray());

--- a/tests/_fixtures/Shopware6/Order/01-HappyCase/output.php
+++ b/tests/_fixtures/Shopware6/Order/01-HappyCase/output.php
@@ -435,4 +435,6 @@ return [
         'e3563b3f63c14b52a9b1dedfbc12c2fa',
     ],
     'id' => 'efaf7e8752b242baa67ed795d18f785d',
+    'primaryOrderDeliveryId' => '8c6259d6e4ef44ed93ed244b349305a2',
+    'primaryOrderTransactionId' => 'e6e10333864f49248ecab59e481fe32e',
 ];

--- a/tests/_fixtures/Shopware6/Order/02-WithoutMedia/output.php
+++ b/tests/_fixtures/Shopware6/Order/02-WithoutMedia/output.php
@@ -431,4 +431,6 @@ return [
         'e3563b3f63c14b52a9b1dedfbc12c2fa',
     ],
     'id' => 'efaf7e8752b242baa67ed795d18f785d',
+    'primaryOrderDeliveryId' => '8c6259d6e4ef44ed93ed244b349305a2',
+    'primaryOrderTransactionId' => 'e6e10333864f49248ecab59e481fe32e',
 ];

--- a/tests/_fixtures/Shopware6/Order/03-WithoutProduct/output.php
+++ b/tests/_fixtures/Shopware6/Order/03-WithoutProduct/output.php
@@ -425,4 +425,6 @@ return [
         'e3563b3f63c14b52a9b1dedfbc12c2fa',
     ],
     'id' => 'efaf7e8752b242baa67ed795d18f785d',
+    'primaryOrderDeliveryId' => '8c6259d6e4ef44ed93ed244b349305a2',
+    'primaryOrderTransactionId' => 'e6e10333864f49248ecab59e481fe32e',
 ];

--- a/tests/_fixtures/Shopware6/Order/04-WithAdminUserFlag/output.php
+++ b/tests/_fixtures/Shopware6/Order/04-WithAdminUserFlag/output.php
@@ -437,4 +437,6 @@ return [
     'id' => 'efaf7e8752b242baa67ed795d18f785d',
     'createdById' => '019270bb17fe70158f37ac83eaa7f761',
     'updatedById' => '019270bb17fe70158f37ac83eaa7f762',
+    'primaryOrderDeliveryId' => '8c6259d6e4ef44ed93ed244b349305a2',
+    'primaryOrderTransactionId' => 'e6e10333864f49248ecab59e481fe32e',
 ];


### PR DESCRIPTION
### 1. Why is this change necessary?

closes https://github.com/shopware/shopware/issues/14051

The Migration Assistant does not populate the `primaryOrderDeliveryId` and `primaryOrderTransactionId` fields when migrating orders from Shopware 5 to Shopware 6. These fields were introduced in Shopware 6.7 and are required for proper order handling.

### 2. What does this change do, exactly?

This change updates both OrderConverters to set the primary order delivery and transaction IDs:

- **Shopware 5 → 6 (`Profile/Shopware/Converter/OrderConverter.php`)**: Sets `primaryOrderDeliveryId` to the first delivery's ID and `primaryOrderTransactionId` to the first transaction's ID after they are created.

- **Shopware 6 → 6 (`Profile/Shopware6/Converter/OrderConverter.php`)**: Sets `primaryOrderDeliveryId` and `primaryOrderTransactionId` from the first delivery/transaction if deliveries and transactions exist.

This mirrors the behavior of Shopware 6's core `OrderConverter` which sets these fields when converting a cart to an order.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set up a Shopware 5 shop with existing orders
2. Install the Migration Assistant in a Shopware 6.7+ shop
3. Run a migration for orders
4. Check the migrated orders in the database: `SELECT id, primary_order_delivery_id, primary_order_transaction_id FROM \`order\``
5. **Before fix**: Both fields are `NULL`
6. **After fix**: Both fields are populated with the correct delivery/transaction IDs

### 5. Checklist

- [x] I have created the PR in draft status and only open it when it's ready for review
- [x] If the change is large: I have thought about splitting it up into smaller PRs
- [x] I have written tests and if it's a bug fix verified that they fail without my change or that new code is covered by tests
- [ ] I have updated developer-facing release notes if this change affects external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] I added the correct package annotation to each `src` file (not strictly necessary for tests)
- [x] This change has code comments where appropriate, especially for non-obvious lines of code
- [x] Ensure the pull request title as well as first commit follows conventional commits
- [x] I have thought about well-defined extension points and marked everything else as `@internal` / `@private`