### PR TITLE
feat: prepare ui for different resolving types

### DIFF
--- a/src/Migration/Validation/Log/MigrationValidationMissingRequiredFieldLog.php
+++ b/src/Migration/Validation/Log/MigrationValidationMissingRequiredFieldLog.php
@@ -15,7 +15,7 @@ readonly class MigrationValidationMissingRequiredFieldLog extends AbstractMigrat
 {
     public function isUserFixable(): bool
     {
-        return true;
+        return false;
     }
 
     public function getLevel(): string

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
@@ -11,6 +11,19 @@ const { Criteria } = Shopware.Data;
 
 /**
  * @private
+ *
+ * Determines which component resolves a specific error code.
+ * 'DEFAULT' means the default component renders a matching input field.
+ * null will render an unresolvable message.
+ */
+export const ERROR_CODE_COMPONENT_MAPPING: Record<string, string> = {
+    SWAG_MIGRATION_VALIDATION_INVALID_FIELD_VALUE: 'DEFAULT',
+    SWAG_MIGRATION_VALIDATION_INVALID_FOREIGN_KEY: 'DEFAULT',
+    SWAG_MIGRATION_VALIDATION_MISSING_REQUIRED_FIELD: 'DEFAULT',
+} as const;
+
+/**
+ * @private
  */
 export type ResolutionModalRow = {
     status: boolean;
@@ -153,6 +166,10 @@ export default Shopware.Component.wrapComponentConfig({
             });
 
             return selection;
+        },
+
+        resolvingComponent(): string | null {
+            return ERROR_CODE_COMPONENT_MAPPING[this.selectedLog.code] || null;
         },
     },
 

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/swag-migration-error-resolution-modal.html.twig
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/swag-migration-error-resolution-modal.html.twig
@@ -86,20 +86,40 @@
                     </div>
 
                     <div class="swag-migration-error-resolution-modal__right-content">
-                        <swag-migration-error-resolution-field
-                            :log="selectedLog"
-                            :disabled="loading || selectedLogIds.length === 0"
-                        />
+                        <div v-if="resolvingComponent === 'DEFAULT'" class="swag-migration-error-resolution-modal__right-content-default">
+                            <swag-migration-error-resolution-field
+                                :log="selectedLog"
+                                :disabled="loading || selectedLogIds.length === 0"
+                            />
 
-                        <mt-button
-                            class="swag-migration-error-resolution-modal__right-content-button"
-                            variant="primary"
-                            :is-loading="submitLoading"
-                            :disabled="loading || selectedLogIds.length === 0"
-                            @click="onSubmitResolution"
-                        >
-                            {{ $tc('swag-migration.index.error-resolution.modals.error.right.apply') }}
-                        </mt-button>
+                            <mt-button
+                                class="swag-migration-error-resolution-modal__right-content-button"
+                                variant="primary"
+                                :is-loading="submitLoading"
+                                :disabled="loading || selectedLogIds.length === 0"
+                                @click="onSubmitResolution"
+                            >
+                                {{ $tc('swag-migration.index.error-resolution.modals.error.right.apply') }}
+                            </mt-button>
+                        </div>
+
+                        <div v-else-if="resolvingComponent !== null" class="swag-migration-error-resolution-modal__right-content-resolving">
+                            <component
+                                :is="resolvingComponent"
+                                :selected-log="selectedLog"
+                                :selected-log-ids="selectedLogIds"
+                                @submit-resolution="onSubmitResolution"
+                            />
+                        </div>
+
+                        <div v-else class="swag-migration-error-resolution-modal__right-content-unresolvable">
+                            <mt-banner
+                                :title="$tc('swag-migration.index.error-resolution.modals.error.right.unresolvableBanner.title')"
+                                variant="attention"
+                            >
+                                {{ $tc('swag-migration.index.error-resolution.modals.error.right.unresolvableBanner.content') }}
+                            </mt-banner>
+                        </div>
                     </div>
                 </div>
             {% endblock %}

--- a/src/Resources/app/administration/src/module/swag-migration/snippet/de.json
+++ b/src/Resources/app/administration/src/module/swag-migration/snippet/de.json
@@ -747,6 +747,10 @@
                 "title": "Unbekannter Feldtyp",
                 "content": "Der Feldtyp konnte nicht ermittelt werden. Bitte korrigieren Sie die Rohdaten."
               },
+              "unresolvableBanner": {
+                "title": "Dieser Fehler kann derzeit nicht über den Migration Assistant behoben werden.",
+                "content": "Weitere Informationen finden sich in der Log-Datei."
+              },
               "apply": "Änderungen anwenden"
             }
           },

--- a/src/Resources/app/administration/src/module/swag-migration/snippet/en.json
+++ b/src/Resources/app/administration/src/module/swag-migration/snippet/en.json
@@ -598,6 +598,10 @@
                 "title": "Unknown field type",
                 "content": "The field type could not be determined. Please correct the raw source data. The value has to be in the correct format."
               },
+              "unresolvableBanner": {
+                "title": "This error currently cannot be resolved via the Migration Assistant",
+                "content": "Please check the log file for more information."
+              },
               "apply": "Apply changes"
             }
           },

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
@@ -2,7 +2,9 @@
  * @sw-package after-sales
  */
 import { mount } from '@vue/test-utils';
-import SwagMigrationErrorResolutionModal from 'SwagMigrationAssistant/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal';
+import SwagMigrationErrorResolutionModal, {
+    ERROR_CODE_COMPONENT_MAPPING,
+} from 'SwagMigrationAssistant/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal';
 import SwagMigrationErrorResolutionDetailsModal from 'SwagMigrationAssistant/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-details-modal';
 import SwagMigrationErrorResolutionField from 'SwagMigrationAssistant/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field';
 import SwagMigrationErrorResolutionFieldScalar from 'SwagMigrationAssistant/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar';
@@ -174,6 +176,16 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
     afterEach(() => {
         jest.clearAllMocks();
         Shopware.Store.get('notification').$reset();
+    });
+
+    describe('constants', () => {
+        it('should provide error code to component mapping', () => {
+            expect(ERROR_CODE_COMPONENT_MAPPING).toStrictEqual({
+                SWAG_MIGRATION_VALIDATION_INVALID_FIELD_VALUE: 'DEFAULT',
+                SWAG_MIGRATION_VALIDATION_INVALID_FOREIGN_KEY: 'DEFAULT',
+                SWAG_MIGRATION_VALIDATION_MISSING_REQUIRED_FIELD: 'DEFAULT',
+            });
+        });
     });
 
     describe('initial loading', () => {
@@ -503,6 +515,39 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
     });
 
     describe('create resolution fix', () => {
+        it.each(Object.keys(ERROR_CODE_COMPONENT_MAPPING).map((code) => ({ code })))(
+            'should render default resolve component for defined codes: $code',
+            async ({ code }) => {
+                const wrapper = await createWrapper({
+                    ...defaultProps,
+                    selectedLog: {
+                        ...fixtureLogGroups.at(1),
+                        code: code,
+                        entityName: 'media',
+                        fieldName: 'title',
+                    },
+                });
+                await flushPromises();
+
+                expect(wrapper.find('.swag-migration-error-resolution-modal__right-content-default').exists()).toBe(true);
+            },
+        );
+
+        it('should render unresolvable field component for unsupported error codes', async () => {
+            const wrapper = await createWrapper({
+                ...defaultProps,
+                selectedLog: {
+                    ...fixtureLogGroups.at(1),
+                    code: 'SOME_UNSUPPORTED_ERROR_CODE',
+                    entityName: 'media',
+                    fieldName: 'title',
+                },
+            });
+            await flushPromises();
+
+            expect(wrapper.find('.swag-migration-error-resolution-modal__right-content-unresolvable').exists()).toBe(true);
+        });
+
         it('should disable input & create button when no logs are selected', async () => {
             const wrapper = await createWrapper();
             await flushPromises();
@@ -569,7 +614,7 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
             const wrapper = await createWrapper({
                 ...defaultProps,
                 selectedLog: {
-                    ...fixtureLogGroups.at(2),
+                    ...fixtureLogGroups.at(1),
                     entityName: 'product',
                     fieldName: 'taxId',
                 },

--- a/tests/unit/Migration/Logging/Log/MigrationLogTest.php
+++ b/tests/unit/Migration/Logging/Log/MigrationLogTest.php
@@ -125,7 +125,7 @@ class MigrationLogTest extends TestCase
             'logClass' => MigrationValidationMissingRequiredFieldLog::class,
             'code' => 'SWAG_MIGRATION_VALIDATION_MISSING_REQUIRED_FIELD',
             'level' => AbstractMigrationLogEntry::LOG_LEVEL_ERROR,
-            'userFixable' => true,
+            'userFixable' => false,
         ];
 
         yield MigrationValidationUnexpectedFieldLog::class => [


### PR DESCRIPTION
currently for every error a input field & apply button would be rendered, but as we might add different types of error as `fixable = true` be will need custom components for this. 