### PR TITLE
feat: add validation of resolution values

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -139,12 +139,12 @@
 - [BREAKING] [#51](https://github.com/shopware/SwagMigrationAssistant/pull/51) - feat!: add migration validation of converted data
     - [BREAKING] Added validation check of converted data to `convertData(...)` method in `SwagMigrationAssistant\Migration\Service\MigrationDataConverter`
     - Added `hasValidMappingByEntityId(...)` to `SwagMigrationAssistant\Migration\Mapping\MappingService` and `SwagMigrationAssistant\Migration\Mapping\MappingServiceInterface` to check if a mapping exists and is valid for a given entity and source id
-    - Added new service `SwagMigrationAssistant\Migration\Validation\MigrationValidationService` to validate converted data against Shopware's data definitions
+    - Added new service `SwagMigrationAssistant\Migration\Validation\MigrationEntityValidationService` to validate converted data against Shopware's data definitions
     - Added new events `SwagMigrationAssistant\Migration\Validation\Event\MigrationPreValidationEvent` and `SwagMigrationAssistant\Migration\Validation\Event\MigrationPostValidationEvent` to allow extensions to hook into the validation process
     - Added new log classes `ValidationInvalidFieldValueLog`, `ValidationInvalidForeignKeyLog`, `ValidationMissingRequiredFieldLog` and `ValidationUnexpectedFieldLog` to log validation errors
     - Added new context class `SwagMigrationAssistant\Migration\Validation\MigrationValidationContext` to pass validation related data
     - Added new result class `SwagMigrationAssistant\Migration\Validation\MigrationValidationResult` to collect validation results
-    - Added new service `SwagMigrationAssistant\Migration\Validation\MigrationValidationService` to validate converted data against Shopware's data definitions in three steps:
+    - Added new service `SwagMigrationAssistant\Migration\Validation\MigrationEntityValidationService` to validate converted data against Shopware's data definitions in three steps:
         - Entity structure: Check for unexpected fields
         - Field Validation: Check for missing required fields and invalid field values
         - Association Validation: Check for invalid foreign keys

--- a/src/Controller/DataProviderController.php
+++ b/src/Controller/DataProviderController.php
@@ -19,7 +19,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Routing\RoutingException;
+use Shopware\Core\PlatformRequest;
 use SwagMigrationAssistant\DataProvider\Provider\ProviderRegistryInterface;
 use SwagMigrationAssistant\DataProvider\Service\EnvironmentServiceInterface;
 use SwagMigrationAssistant\Exception\MigrationException;
@@ -32,7 +34,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(defaults: ['_routeScope' => ['api']])]
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
 #[Package('fundamentals@after-sales')]
 class DataProviderController extends AbstractController
 {
@@ -54,7 +56,7 @@ class DataProviderController extends AbstractController
     #[Route(
         path: '/api/_action/data-provider/get-environment',
         name: 'api.admin.data-provider.get-environment',
-        defaults: ['_acl' => ['admin']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['admin']],
         methods: [Request::METHOD_GET]
     )]
     public function getEnvironment(Context $context): JsonResponse
@@ -67,7 +69,7 @@ class DataProviderController extends AbstractController
     #[Route(
         path: '/api/_action/data-provider/get-data',
         name: 'api.admin.data-provider.get-data',
-        defaults: ['_acl' => ['admin']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['admin']],
         methods: [Request::METHOD_GET]
     )]
     public function getData(Request $request, Context $context): JsonResponse
@@ -89,7 +91,7 @@ class DataProviderController extends AbstractController
     #[Route(
         path: '/api/_action/data-provider/get-total',
         name: 'api.admin.data-provider.get-total',
-        defaults: ['_acl' => ['admin']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['admin']],
         methods: [Request::METHOD_GET]
     )]
     public function getTotal(Request $request, Context $context): JsonResponse
@@ -107,7 +109,7 @@ class DataProviderController extends AbstractController
     #[Route(
         path: '/api/_action/data-provider/get-table',
         name: 'api.admin.data-provider.get-table',
-        defaults: ['_acl' => ['admin']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['admin']],
         methods: [Request::METHOD_GET]
     )]
     public function getTable(Request $request, Context $context): JsonResponse
@@ -127,7 +129,7 @@ class DataProviderController extends AbstractController
     #[Route(
         path: '/api/_action/data-provider/generate-document',
         name: 'api.admin.data-provider.generate-document',
-        defaults: ['_acl' => ['admin']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['admin']],
         methods: [Request::METHOD_GET]
     )]
     public function generateDocument(Request $request, Context $context): JsonResponse
@@ -154,7 +156,7 @@ class DataProviderController extends AbstractController
     #[Route(
         path: '/api/_action/data-provider/download-private-file/{file}',
         name: 'api.admin.data-provider.download-private-file',
-        defaults: ['_acl' => ['admin']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['admin']],
         methods: [Request::METHOD_GET]
     )]
     public function downloadPrivateFile(Request $request, Context $context): StreamedResponse|RedirectResponse

--- a/src/Controller/ErrorResolutionController.php
+++ b/src/Controller/ErrorResolutionController.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SwagMigrationAssistant\Controller;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use SwagMigrationAssistant\Exception\MigrationException;
+use SwagMigrationAssistant\Migration\ErrorResolution\MigrationFieldExampleGenerator;
+use SwagMigrationAssistant\Migration\Validation\MigrationFieldValidationService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(defaults: ['_routeScope' => ['api']])]
+#[Package('fundamentals@after-sales')]
+class ErrorResolutionController extends AbstractController
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly DefinitionInstanceRegistry $definitionRegistry,
+        private readonly MigrationFieldValidationService $fieldValidationService,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/_action/migration/error-resolution/validate',
+        name: 'api.admin.migration.error-resolution.validate',
+        defaults: ['_acl' => ['swag_migration.viewer']],
+        methods: [Request::METHOD_POST]
+    )]
+    public function validateResolution(Request $request, Context $context): JsonResponse
+    {
+        $entityName = (string) $request->request->get('entityName');
+        $fieldName = (string) $request->request->get('fieldName');
+
+        if ($entityName === '') {
+            throw MigrationException::missingRequestParameter('entityName');
+        }
+
+        if ($fieldName === '') {
+            throw MigrationException::missingRequestParameter('fieldName');
+        }
+
+        $fieldValue = $this->decodeFieldValue($request->request->all()['fieldValue'] ?? null);
+
+        if ($fieldValue === null) {
+            throw MigrationException::missingRequestParameter('fieldValue');
+        }
+
+        try {
+            $this->fieldValidationService->validateFieldValue(
+                $entityName,
+                $fieldName,
+                $fieldValue,
+                $context,
+            );
+        } catch (WriteConstraintViolationException $e) {
+            return new JsonResponse([
+                'valid' => false,
+                'violations' => $e->toArray(),
+            ]);
+        } catch (\Exception $e) {
+            return new JsonResponse([
+                'valid' => false,
+                'violations' => [['message' => $e->getMessage()]],
+            ]);
+        }
+
+        return new JsonResponse([
+            'valid' => true,
+            'violations' => [],
+        ]);
+    }
+
+    #[Route(
+        path: '/api/_action/migration/error-resolution/example-field-structure',
+        name: 'api.admin.migration.error-resolution.example-field-structure',
+        defaults: ['_acl' => ['swag_migration.viewer']],
+        methods: [Request::METHOD_POST]
+    )]
+    public function getExampleFieldStructure(Request $request): JsonResponse
+    {
+        $entityName = (string) $request->request->get('entityName');
+        $fieldName = (string) $request->request->get('fieldName');
+
+        if ($entityName === '') {
+            throw MigrationException::missingRequestParameter('entityName');
+        }
+
+        if ($fieldName === '') {
+            throw MigrationException::missingRequestParameter('fieldName');
+        }
+
+        $entityDefinition = $this->definitionRegistry->getByEntityName($entityName);
+        $fields = $entityDefinition->getFields();
+
+        if (!$fields->has($fieldName)) {
+            throw MigrationException::entityFieldNotFound($entityName, $fieldName);
+        }
+
+        $field = $fields->get($fieldName);
+
+        $response = [
+            'fieldType' => MigrationFieldExampleGenerator::getFieldType($field),
+            'example' => MigrationFieldExampleGenerator::generateExample($field),
+        ];
+
+        return new JsonResponse($response);
+    }
+
+    /**
+     * @return array<array-key, mixed>|bool|float|int|string|null
+     */
+    private function decodeFieldValue(mixed $value): array|bool|float|int|string|null
+    {
+        if ($value === null || $value === '' || $value === []) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            return $value;
+        }
+
+        $decoded = \json_decode($value, true);
+
+        return \json_last_error() === \JSON_ERROR_NONE ? $decoded : $value;
+    }
+}

--- a/src/Controller/ErrorResolutionController.php
+++ b/src/Controller/ErrorResolutionController.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use Shopware\Core\PlatformRequest;
 use SwagMigrationAssistant\Exception\MigrationException;
 use SwagMigrationAssistant\Migration\ErrorResolution\MigrationFieldExampleGenerator;
+use SwagMigrationAssistant\Migration\Validation\Exception\MigrationValidationException;
 use SwagMigrationAssistant\Migration\Validation\MigrationFieldValidationService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -60,21 +61,30 @@ class ErrorResolutionController extends AbstractController
         }
 
         try {
-            $this->fieldValidationService->validateFieldValue(
+            $this->fieldValidationService->validateField(
                 $entityName,
                 $fieldName,
                 $fieldValue,
                 $context,
             );
-        } catch (WriteConstraintViolationException $e) {
+        } catch (MigrationValidationException $exception) {
+            $previous = $exception->getPrevious();
+
+            if ($previous instanceof WriteConstraintViolationException) {
+                return new JsonResponse([
+                    'valid' => false,
+                    'violations' => $previous->toArray(),
+                ]);
+            }
+
             return new JsonResponse([
                 'valid' => false,
-                'violations' => $e->toArray(),
+                'violations' => [['message' => $exception->getMessage()]],
             ]);
-        } catch (\Exception $e) {
+        } catch (\Exception $exception) {
             return new JsonResponse([
                 'valid' => false,
-                'violations' => [['message' => $e->getMessage()]],
+                'violations' => [['message' => $exception->getMessage()]],
             ]);
         }
 
@@ -107,7 +117,7 @@ class ErrorResolutionController extends AbstractController
         $fields = $entityDefinition->getFields();
 
         if (!$fields->has($fieldName)) {
-            throw MigrationException::entityFieldNotFound($entityName, $fieldName);
+            throw MigrationValidationException::entityFieldNotFound($entityName, $fieldName);
         }
 
         $field = $fields->get($fieldName);

--- a/src/Controller/ErrorResolutionController.php
+++ b/src/Controller/ErrorResolutionController.php
@@ -10,7 +10,9 @@ namespace SwagMigrationAssistant\Controller;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\PlatformRequest;
 use SwagMigrationAssistant\Exception\MigrationException;
 use SwagMigrationAssistant\Migration\ErrorResolution\MigrationFieldExampleGenerator;
 use SwagMigrationAssistant\Migration\Validation\MigrationFieldValidationService;
@@ -19,7 +21,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(defaults: ['_routeScope' => ['api']])]
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
 #[Package('fundamentals@after-sales')]
 class ErrorResolutionController extends AbstractController
 {
@@ -35,7 +37,7 @@ class ErrorResolutionController extends AbstractController
     #[Route(
         path: '/api/_action/migration/error-resolution/validate',
         name: 'api.admin.migration.error-resolution.validate',
-        defaults: ['_acl' => ['swag_migration.viewer']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
         methods: [Request::METHOD_POST]
     )]
     public function validateResolution(Request $request, Context $context): JsonResponse
@@ -85,7 +87,7 @@ class ErrorResolutionController extends AbstractController
     #[Route(
         path: '/api/_action/migration/error-resolution/example-field-structure',
         name: 'api.admin.migration.error-resolution.example-field-structure',
-        defaults: ['_acl' => ['swag_migration.viewer']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
         methods: [Request::METHOD_POST]
     )]
     public function getExampleFieldStructure(Request $request): JsonResponse

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -9,7 +9,9 @@ namespace SwagMigrationAssistant\Controller;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Routing\RoutingException;
+use Shopware\Core\PlatformRequest;
 use SwagMigrationAssistant\Exception\MigrationException;
 use SwagMigrationAssistant\Migration\History\HistoryServiceInterface;
 use SwagMigrationAssistant\Migration\History\LogGroupingService;
@@ -22,7 +24,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-#[Route(defaults: ['_routeScope' => ['api']])]
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
 #[Package('fundamentals@after-sales')]
 class HistoryController extends AbstractController
 {
@@ -35,7 +37,12 @@ class HistoryController extends AbstractController
     ) {
     }
 
-    #[Route(path: '/api/_action/migration/get-grouped-logs-of-run', name: 'api.admin.migration.get-grouped-logs-of-run', methods: ['GET'], defaults: ['_acl' => ['swag_migration.viewer']])]
+    #[Route(
+        path: '/api/_action/migration/get-grouped-logs-of-run',
+        name: 'api.admin.migration.get-grouped-logs-of-run',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
+        methods: [Request::METHOD_GET],
+    )]
     public function getGroupedLogsOfRun(Request $request, Context $context): JsonResponse
     {
         $runUuid = $request->query->getAlnum('runUuid');
@@ -60,7 +67,12 @@ class HistoryController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/api/_action/migration/download-logs-of-run', name: 'api.admin.migration.download-logs-of-run', methods: ['POST'], defaults: ['auth_required' => false, '_acl' => ['swag_migration.viewer']])]
+    #[Route(
+        path: '/api/_action/migration/download-logs-of-run',
+        name: 'api.admin.migration.download-logs-of-run',
+        defaults: ['auth_required' => false, PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
+        methods: [Request::METHOD_POST],
+    )]
     public function downloadLogsOfRun(Request $request, Context $context): StreamedResponse
     {
         $runUuid = $request->request->getAlnum('runUuid');
@@ -86,7 +98,12 @@ class HistoryController extends AbstractController
         return $response;
     }
 
-    #[Route(path: '/api/_action/migration/clear-data-of-run', name: 'api.admin.migration.clear-data-of-run', methods: ['POST'], defaults: ['_acl' => ['swag_migration.deleter']])]
+    #[Route(
+        path: '/api/_action/migration/clear-data-of-run',
+        name: 'api.admin.migration.clear-data-of-run',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.deleter']],
+        methods: [Request::METHOD_POST],
+    )]
     public function clearDataOfRun(Request $request, Context $context): Response
     {
         $runUuid = $request->request->getAlnum('runUuid');
@@ -104,7 +121,12 @@ class HistoryController extends AbstractController
         return new Response();
     }
 
-    #[Route(path: '/api/_action/migration/is-media-processing', name: 'api.admin.migration.is-media-processing', methods: ['GET'], defaults: ['_acl' => ['swag_migration_history:read']])]
+    #[Route(
+        path: '/api/_action/migration/is-media-processing',
+        name: 'api.admin.migration.is-media-processing',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration_history:read']],
+        methods: [Request::METHOD_GET],
+    )]
     public function isMediaProcessing(): JsonResponse
     {
         $result = $this->historyService->isMediaProcessing();
@@ -115,8 +137,8 @@ class HistoryController extends AbstractController
     #[Route(
         path: '/api/_action/migration/get-log-groups',
         name: 'api.admin.migration.get-log-groups',
-        methods: ['GET'],
-        defaults: ['_acl' => ['swag_migration.viewer']]
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
+        methods: [Request::METHOD_GET],
     )]
     public function getLogGroups(Request $request, Context $context): JsonResponse
     {
@@ -166,8 +188,8 @@ class HistoryController extends AbstractController
     #[Route(
         path: '/api/_action/migration/get-all-log-ids',
         name: 'api.admin.migration.get-all-log-ids',
-        methods: ['POST'],
-        defaults: ['_acl' => ['swag_migration.viewer']]
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
+        methods: [Request::METHOD_POST],
     )]
     public function getAllLogIds(Request $request): JsonResponse
     {

--- a/src/Controller/PremappingController.php
+++ b/src/Controller/PremappingController.php
@@ -9,7 +9,9 @@ namespace SwagMigrationAssistant\Controller;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Routing\RoutingException;
+use Shopware\Core\PlatformRequest;
 use SwagMigrationAssistant\Migration\MigrationContextFactoryInterface;
 use SwagMigrationAssistant\Migration\Service\PremappingServiceInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -18,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(defaults: ['_routeScope' => ['api']])]
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
 #[Package('fundamentals@after-sales')]
 class PremappingController extends AbstractController
 {
@@ -31,7 +33,12 @@ class PremappingController extends AbstractController
     ) {
     }
 
-    #[Route(path: '/api/_action/migration/generate-premapping', name: 'api.admin.migration.generate-premapping', methods: ['POST'], defaults: ['_acl' => ['swag_migration.editor']])]
+    #[Route(
+        path: '/api/_action/migration/generate-premapping',
+        name: 'api.admin.migration.generate-premapping',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.editor']],
+        methods: [Request::METHOD_POST],
+    )]
     public function generatePremapping(Request $request, Context $context): JsonResponse
     {
         $dataSelectionIds = $request->request->all('dataSelectionIds');
@@ -44,7 +51,12 @@ class PremappingController extends AbstractController
         return new JsonResponse($this->premappingService->generatePremapping($context, $migrationContext, $dataSelectionIds));
     }
 
-    #[Route(path: '/api/_action/migration/write-premapping', name: 'api.admin.migration.write-premapping', methods: ['POST'], defaults: ['_acl' => ['swag_migration.editor']])]
+    #[Route(
+        path: '/api/_action/migration/write-premapping',
+        name: 'api.admin.migration.write-premapping',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.editor']],
+        methods: [Request::METHOD_POST],
+    )]
     public function writePremapping(Request $request, Context $context): Response
     {
         $premapping = $request->request->all('premapping');

--- a/src/Controller/StatusController.php
+++ b/src/Controller/StatusController.php
@@ -11,7 +11,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Routing\RoutingException;
+use Shopware\Core\PlatformRequest;
 use SwagMigrationAssistant\Exception\MigrationException;
 use SwagMigrationAssistant\Migration\Connection\Fingerprint\MigrationFingerprintServiceInterface;
 use SwagMigrationAssistant\Migration\Connection\SwagMigrationConnectionCollection;
@@ -30,7 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(defaults: ['_routeScope' => ['api']])]
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
 #[Package('fundamentals@after-sales')]
 class StatusController extends AbstractController
 {
@@ -56,7 +58,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/get-profile-information',
         name: 'api.admin.migration.get-profile-information',
-        defaults: ['_acl' => ['swag_migration.viewer']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
         methods: [Request::METHOD_GET]
     )]
     public function getProfileInformation(Request $request): Response
@@ -126,7 +128,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/get-profiles',
         name: 'api.admin.migration.get-profiles',
-        defaults: ['_acl' => ['swag_migration.viewer']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
         methods: [Request::METHOD_GET]
     )]
     public function getProfiles(): JsonResponse
@@ -149,7 +151,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/get-gateways',
         name: 'api.admin.migration.get-gateways',
-        defaults: ['_acl' => ['swag_migration.viewer']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
         methods: [Request::METHOD_GET]
     )]
     public function getGateways(Request $request): JsonResponse
@@ -180,7 +182,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/update-connection-credentials',
         name: 'api.admin.migration.update-connection-credentials',
-        defaults: ['_acl' => ['swag_migration.editor']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.editor']],
         methods: [Request::METHOD_POST]
     )]
     public function updateConnectionCredentials(Request $request, Context $context): Response
@@ -207,7 +209,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/data-selection',
         name: 'api.admin.migration.data-selection',
-        defaults: ['_acl' => ['swag_migration.viewer']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
         methods: [Request::METHOD_GET]
     )]
     public function getDataSelection(Request $request, Context $context): JsonResponse
@@ -234,7 +236,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/check-connection',
         name: 'api.admin.migration.check-connection',
-        defaults: ['_acl' => ['swag_migration.viewer']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
         methods: [Request::METHOD_POST]
     )]
     public function checkConnection(Request $request, Context $context): JsonResponse
@@ -287,7 +289,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/start-migration',
         name: 'api.admin.migration.start-migration',
-        defaults: ['_acl' => ['swag_migration.creator']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.creator']],
         methods: [Request::METHOD_POST]
     )]
     public function startMigration(Request $request, Context $context): Response
@@ -320,7 +322,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/get-state',
         name: 'api.admin.migration.get-state',
-        defaults: ['_acl' => ['swag_migration.viewer']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
         methods: [Request::METHOD_GET]
     )]
     public function getState(Context $context): JsonResponse
@@ -331,7 +333,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/approve-finished',
         name: 'api.admin.migration.approveFinished',
-        defaults: ['_acl' => ['swag_migration.editor']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.editor']],
         methods: [Request::METHOD_POST]
     )]
     public function approveFinishedMigration(Context $context): Response
@@ -352,7 +354,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/abort-migration',
         name: 'api.admin.migration.abort-migration',
-        defaults: ['_acl' => ['swag_migration.editor']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.editor']],
         methods: [Request::METHOD_POST]
     )]
     public function abortMigration(Context $context): Response
@@ -365,7 +367,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/reset-checksums',
         name: 'api.admin.migration.reset-checksums',
-        defaults: ['_acl' => ['swag_migration.deleter']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.deleter']],
         methods: [Request::METHOD_POST]
     )]
     public function resetChecksums(Request $request, Context $context): Response
@@ -384,7 +386,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/cleanup-migration-data',
         name: 'api.admin.migration.cleanup-migration-data',
-        defaults: ['_acl' => ['swag_migration.deleter']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.deleter']],
         methods: [Request::METHOD_POST]
     )]
     public function cleanupMigrationData(Context $context): Response
@@ -397,7 +399,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/is-truncating-migration-data',
         name: 'api.admin.migration.get-reset-status',
-        defaults: ['_acl' => ['swag_migration.viewer']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
         methods: [Request::METHOD_GET]
     )]
     public function isTruncatingMigrationData(Context $context): JsonResponse
@@ -414,7 +416,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/is-resetting-checksums',
         name: 'api.admin.migration.is-resetting-checksums',
-        defaults: ['_acl' => ['swag_migration.viewer']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['swag_migration.viewer']],
         methods: [Request::METHOD_GET]
     )]
     public function isResettingChecksums(Context $context): JsonResponse
@@ -436,7 +438,7 @@ class StatusController extends AbstractController
     #[Route(
         path: '/api/_action/migration/resume-after-fixes',
         name: 'api.admin.migration.resume-after-fixes',
-        defaults: ['_acl' => ['admin']],
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['admin']],
         methods: [Request::METHOD_POST]
     )]
     public function resumeAfterFixes(Context $context): Response

--- a/src/DependencyInjection/migration.xml
+++ b/src/DependencyInjection/migration.xml
@@ -295,6 +295,15 @@
             </call>
         </service>
 
+        <service id="SwagMigrationAssistant\Controller\ErrorResolutionController" public="true">
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="SwagMigrationAssistant\Migration\Validation\MigrationFieldValidationService"/>
+
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+
         <service id="SwagMigrationAssistant\Migration\DataSelection\DataSelectionRegistry">
             <argument type="tagged_iterator" tag="shopware.migration.data_selection"/>
         </service>
@@ -425,9 +434,14 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
             <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface"/>
             <argument type="service" id="SwagMigrationAssistant\Migration\Logging\LoggingService"/>
+            <argument type="service" id="SwagMigrationAssistant\Migration\Validation\MigrationFieldValidationService"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
 
             <tag name="kernel.reset" method="reset"/>
+        </service>
+
+        <service id="SwagMigrationAssistant\Migration\Validation\MigrationFieldValidationService">
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
         </service>
     </services>
 </container>

--- a/src/DependencyInjection/migration.xml
+++ b/src/DependencyInjection/migration.xml
@@ -225,7 +225,7 @@
             <argument type="service" id="SwagMigrationAssistant\Migration\Logging\LoggingService"/>
             <argument type="service" id="SwagMigrationAssistant\Migration\Data\SwagMigrationDataDefinition"/>
             <argument type="service" id="SwagMigrationAssistant\Migration\Mapping\MappingService"/>
-            <argument type="service" id="SwagMigrationAssistant\Migration\Validation\MigrationValidationService"/>
+            <argument type="service" id="SwagMigrationAssistant\Migration\Validation\MigrationEntityValidationService"/>
         </service>
 
         <service id="SwagMigrationAssistant\Migration\Service\MigrationDataWriter" public="true">
@@ -430,7 +430,7 @@
                       id="SwagMigrationAssistant\Core\Content\Product\Stock\StockStorageDecorator.inner"/>
         </service>
 
-        <service id="SwagMigrationAssistant\Migration\Validation\MigrationValidationService">
+        <service id="SwagMigrationAssistant\Migration\Validation\MigrationEntityValidationService">
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
             <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface"/>
             <argument type="service" id="SwagMigrationAssistant\Migration\Logging\LoggingService"/>

--- a/src/Exception/MigrationException.php
+++ b/src/Exception/MigrationException.php
@@ -93,6 +93,10 @@ class MigrationException extends HttpException
 
     final public const DUPLICATE_SOURCE_CONNECTION = 'SWAG_MIGRATION__DUPLICATE_SOURCE_CONNECTION';
 
+    final public const MISSING_REQUEST_PARAMETER = 'SWAG_MIGRATION__MISSING_REQUEST_PARAMETER';
+
+    final public const ENTITY_FIELD_NOT_FOUND = 'SWAG_MIGRATION__ENTITY_FIELD_NOT_FOUND';
+
     public static function associationEntityRequiredMissing(string $entity, string $missingEntity): self
     {
         return new self(
@@ -474,6 +478,26 @@ class MigrationException extends HttpException
             Response::HTTP_CONFLICT,
             self::DUPLICATE_SOURCE_CONNECTION,
             'A connection to this source system already exists.',
+        );
+    }
+
+    public static function missingRequestParameter(string $parameterName): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::MISSING_REQUEST_PARAMETER,
+            'Required request parameter "{{ parameterName }}" is missing.',
+            ['parameterName' => $parameterName]
+        );
+    }
+
+    public static function entityFieldNotFound(string $entityName, string $fieldName): self
+    {
+        return new self(
+            Response::HTTP_NOT_FOUND,
+            self::ENTITY_FIELD_NOT_FOUND,
+            'Field "{{ fieldName }}" not found in entity "{{ entityName }}".',
+            ['fieldName' => $fieldName, 'entityName' => $entityName]
         );
     }
 }

--- a/src/Exception/MigrationException.php
+++ b/src/Exception/MigrationException.php
@@ -95,8 +95,6 @@ class MigrationException extends HttpException
 
     final public const MISSING_REQUEST_PARAMETER = 'SWAG_MIGRATION__MISSING_REQUEST_PARAMETER';
 
-    final public const ENTITY_FIELD_NOT_FOUND = 'SWAG_MIGRATION__ENTITY_FIELD_NOT_FOUND';
-
     public static function associationEntityRequiredMissing(string $entity, string $missingEntity): self
     {
         return new self(
@@ -488,16 +486,6 @@ class MigrationException extends HttpException
             self::MISSING_REQUEST_PARAMETER,
             'Required request parameter "{{ parameterName }}" is missing.',
             ['parameterName' => $parameterName]
-        );
-    }
-
-    public static function entityFieldNotFound(string $entityName, string $fieldName): self
-    {
-        return new self(
-            Response::HTTP_NOT_FOUND,
-            self::ENTITY_FIELD_NOT_FOUND,
-            'Field "{{ fieldName }}" not found in entity "{{ entityName }}".',
-            ['fieldName' => $fieldName, 'entityName' => $entityName]
         );
     }
 }

--- a/src/Migration/ErrorResolution/MigrationFieldExampleGenerator.php
+++ b/src/Migration/ErrorResolution/MigrationFieldExampleGenerator.php
@@ -10,6 +10,7 @@ namespace SwagMigrationAssistant\Migration\ErrorResolution;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CalculatedPriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CartPriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CashRoundingConfigField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
@@ -24,6 +25,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ObjectField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceDefinitionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TaxFreeConfigField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VariantListingConfigField;
 use Shopware\Core\Framework\Log\Package;
 
@@ -67,10 +69,6 @@ readonly class MigrationFieldExampleGenerator
             return null;
         }
 
-        if ($field instanceof JsonField && !empty($field->getPropertyMapping())) {
-            return self::buildFromPropertyMapping($field->getPropertyMapping());
-        }
-
         if ($field instanceof ListField) {
             $fieldType = $field->getFieldType();
 
@@ -86,7 +84,11 @@ readonly class MigrationFieldExampleGenerator
         }
 
         if ($field instanceof JsonField) {
-            return [];
+            if (empty($field->getPropertyMapping())) {
+                return [];
+            }
+
+            return self::buildFromPropertyMapping($field->getPropertyMapping());
         }
 
         return self::getScalarDefault($field);
@@ -112,11 +114,12 @@ readonly class MigrationFieldExampleGenerator
     {
         return match (true) {
             $field instanceof IntField => 0,
-            $field instanceof FloatField => 0.0,
+            $field instanceof FloatField => 0.1,
             $field instanceof BoolField => false,
-            $field instanceof StringField => '',
+            $field instanceof StringField => '[string]',
             $field instanceof IdField, $field instanceof FkField => '[uuid]',
-            $field instanceof DateTimeField, $field instanceof DateField => '[date]',
+            $field instanceof DateField => '[date]',
+            $field instanceof DateTimeField => '[datetime]',
             default => null,
         };
     }
@@ -130,8 +133,8 @@ readonly class MigrationFieldExampleGenerator
             $field instanceof PriceField => [
                 [
                     'currencyId' => '[uuid]',
-                    'gross' => 0.0,
-                    'net' => 0.0,
+                    'gross' => 0.1,
+                    'net' => 0.1,
                     'linked' => false,
                 ],
             ],
@@ -142,53 +145,63 @@ readonly class MigrationFieldExampleGenerator
             ],
             $field instanceof PriceDefinitionField => [
                 'type' => 'quantity',
-                'price' => 0.0,
+                'price' => 0.1,
                 'quantity' => 1,
                 'isCalculated' => false,
                 'taxRules' => [
                     [
-                        'taxRate' => 0.0,
-                        'percentage' => 0.0,
+                        'taxRate' => 0.1,
+                        'percentage' => 0.1,
                     ],
                 ],
             ],
             $field instanceof CartPriceField => [
-                'netPrice' => 0.0,
-                'totalPrice' => 0.0,
-                'positionPrice' => 0.0,
-                'rawTotal' => 0.0,
+                'netPrice' => 0.1,
+                'totalPrice' => 0.1,
+                'positionPrice' => 0.1,
+                'rawTotal' => 0.1,
                 'taxStatus' => 'gross',
                 'calculatedTaxes' => [
                     [
-                        'tax' => 0.0,
-                        'taxRate' => 0.0,
-                        'price' => 0.0,
+                        'tax' => 0.1,
+                        'taxRate' => 0.1,
+                        'price' => 0.1,
                     ],
                 ],
                 'taxRules' => [
                     [
-                        'taxRate' => 0.0,
-                        'percentage' => 0.0,
+                        'taxRate' => 0.1,
+                        'percentage' => 0.1,
                     ],
                 ],
             ],
             $field instanceof CalculatedPriceField => [
-                'unitPrice' => 0.0,
-                'totalPrice' => 0.0,
+                'unitPrice' => 0.1,
+                'totalPrice' => 0.1,
                 'quantity' => 1,
                 'calculatedTaxes' => [
                     [
-                        'tax' => 0.0,
-                        'taxRate' => 0.0,
-                        'price' => 0.0,
+                        'tax' => 0.1,
+                        'taxRate' => 0.1,
+                        'price' => 0.1,
                     ],
                 ],
                 'taxRules' => [
                     [
-                        'taxRate' => 0.0,
-                        'percentage' => 0.0,
+                        'taxRate' => 0.1,
+                        'percentage' => 0.1,
                     ],
                 ],
+            ],
+            $field instanceof CashRoundingConfigField => [
+                'decimals' => 2,
+                'interval' => 0.01,
+                'roundForNet' => true,
+            ],
+            $field instanceof TaxFreeConfigField => [
+                'enabled' => false,
+                'currencyId' => '[uuid]',
+                'amount' => 0.1,
             ],
             default => null,
         };

--- a/src/Migration/ErrorResolution/MigrationFieldExampleGenerator.php
+++ b/src/Migration/ErrorResolution/MigrationFieldExampleGenerator.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceDefinitionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TaxFreeConfigField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VariantListingConfigField;
 use Shopware\Core\Framework\Log\Package;
 
@@ -117,7 +118,7 @@ readonly class MigrationFieldExampleGenerator
             $field instanceof IntField => 0,
             $field instanceof FloatField => 0.1,
             $field instanceof BoolField => false,
-            $field instanceof StringField => '[string]',
+            $field instanceof StringField, $field instanceof TranslatedField => '[string]',
             $field instanceof IdField, $field instanceof FkField => '[uuid]',
             $field instanceof DateField => \sprintf('[date (%s)]', Defaults::STORAGE_DATE_FORMAT),
             $field instanceof DateTimeField => \sprintf('[datetime (%s)]', Defaults::STORAGE_DATE_TIME_FORMAT),

--- a/src/Migration/ErrorResolution/MigrationFieldExampleGenerator.php
+++ b/src/Migration/ErrorResolution/MigrationFieldExampleGenerator.php
@@ -1,0 +1,196 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SwagMigrationAssistant\Migration\ErrorResolution;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CalculatedPriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CartPriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ObjectField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceDefinitionField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\VariantListingConfigField;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+readonly class MigrationFieldExampleGenerator
+{
+    public static function generateExample(Field $field): ?string
+    {
+        $example = self::buildExample($field);
+
+        if ($example === null) {
+            return null;
+        }
+
+        $encoded = \json_encode($example, \JSON_PRETTY_PRINT);
+
+        if ($encoded === false) {
+            return null;
+        }
+
+        return $encoded;
+    }
+
+    public static function getFieldType(Field $field): string
+    {
+        return (new \ReflectionClass($field))->getShortName();
+    }
+
+    private static function buildExample(Field $field): mixed
+    {
+        $specialExample = self::getSpecialFieldExample($field);
+
+        if ($specialExample !== null) {
+            return $specialExample;
+        }
+
+        if ($field instanceof CustomFields || $field instanceof ObjectField) {
+            return null;
+        }
+
+        if ($field instanceof JsonField && !empty($field->getPropertyMapping())) {
+            return self::buildFromPropertyMapping($field->getPropertyMapping());
+        }
+
+        if ($field instanceof ListField) {
+            $fieldType = $field->getFieldType();
+
+            if ($fieldType === null) {
+                return [];
+            }
+
+            /** @var Field $elementField */
+            $elementField = new $fieldType('example', 'example');
+            $elementExample = self::buildExample($elementField);
+
+            return $elementExample !== null ? [$elementExample] : [];
+        }
+
+        if ($field instanceof JsonField) {
+            return [];
+        }
+
+        return self::getScalarDefault($field);
+    }
+
+    /**
+     * @param list<Field> $fields
+     *
+     * @return array<string, mixed>
+     */
+    private static function buildFromPropertyMapping(array $fields): array
+    {
+        $result = [];
+
+        foreach ($fields as $nestedField) {
+            $result[$nestedField->getPropertyName()] = self::buildExample($nestedField);
+        }
+
+        return $result;
+    }
+
+    private static function getScalarDefault(Field $field): mixed
+    {
+        return match (true) {
+            $field instanceof IntField => 0,
+            $field instanceof FloatField => 0.0,
+            $field instanceof BoolField => false,
+            $field instanceof StringField => '',
+            $field instanceof IdField, $field instanceof FkField => '[uuid]',
+            $field instanceof DateTimeField, $field instanceof DateField => '[date]',
+            default => null,
+        };
+    }
+
+    /**
+     * @return array<string, mixed>|list<array<string, mixed>>|null
+     */
+    private static function getSpecialFieldExample(Field $field): ?array
+    {
+        return match (true) {
+            $field instanceof PriceField => [
+                [
+                    'currencyId' => '[uuid]',
+                    'gross' => 0.0,
+                    'net' => 0.0,
+                    'linked' => false,
+                ],
+            ],
+            $field instanceof VariantListingConfigField => [
+                'displayParent' => false,
+                'mainVariantId' => '[uuid]',
+                'configuratorGroupConfig' => [],
+            ],
+            $field instanceof PriceDefinitionField => [
+                'type' => 'quantity',
+                'price' => 0.0,
+                'quantity' => 1,
+                'isCalculated' => false,
+                'taxRules' => [
+                    [
+                        'taxRate' => 0.0,
+                        'percentage' => 0.0,
+                    ],
+                ],
+            ],
+            $field instanceof CartPriceField => [
+                'netPrice' => 0.0,
+                'totalPrice' => 0.0,
+                'positionPrice' => 0.0,
+                'rawTotal' => 0.0,
+                'taxStatus' => 'gross',
+                'calculatedTaxes' => [
+                    [
+                        'tax' => 0.0,
+                        'taxRate' => 0.0,
+                        'price' => 0.0,
+                    ],
+                ],
+                'taxRules' => [
+                    [
+                        'taxRate' => 0.0,
+                        'percentage' => 0.0,
+                    ],
+                ],
+            ],
+            $field instanceof CalculatedPriceField => [
+                'unitPrice' => 0.0,
+                'totalPrice' => 0.0,
+                'quantity' => 1,
+                'calculatedTaxes' => [
+                    [
+                        'tax' => 0.0,
+                        'taxRate' => 0.0,
+                        'price' => 0.0,
+                    ],
+                ],
+                'taxRules' => [
+                    [
+                        'taxRate' => 0.0,
+                        'percentage' => 0.0,
+                    ],
+                ],
+            ],
+            default => null,
+        };
+    }
+}

--- a/src/Migration/ErrorResolution/MigrationFieldExampleGenerator.php
+++ b/src/Migration/ErrorResolution/MigrationFieldExampleGenerator.php
@@ -7,6 +7,7 @@
 
 namespace SwagMigrationAssistant\Migration\ErrorResolution;
 
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CalculatedPriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CartPriceField;
@@ -118,8 +119,8 @@ readonly class MigrationFieldExampleGenerator
             $field instanceof BoolField => false,
             $field instanceof StringField => '[string]',
             $field instanceof IdField, $field instanceof FkField => '[uuid]',
-            $field instanceof DateField => '[date]',
-            $field instanceof DateTimeField => '[datetime]',
+            $field instanceof DateField => \sprintf('[date (%s)]', Defaults::STORAGE_DATE_FORMAT),
+            $field instanceof DateTimeField => \sprintf('[datetime (%s)]', Defaults::STORAGE_DATE_TIME_FORMAT),
             default => null,
         };
     }

--- a/src/Migration/Service/MigrationDataConverter.php
+++ b/src/Migration/Service/MigrationDataConverter.php
@@ -25,7 +25,7 @@ use SwagMigrationAssistant\Migration\Mapping\MappingDeltaResult;
 use SwagMigrationAssistant\Migration\Mapping\MappingServiceInterface;
 use SwagMigrationAssistant\Migration\Media\MediaFileServiceInterface;
 use SwagMigrationAssistant\Migration\MigrationContextInterface;
-use SwagMigrationAssistant\Migration\Validation\MigrationValidationService;
+use SwagMigrationAssistant\Migration\Validation\MigrationEntityValidationService;
 
 #[Package('fundamentals@after-sales')]
 class MigrationDataConverter implements MigrationDataConverterInterface
@@ -37,7 +37,7 @@ class MigrationDataConverter implements MigrationDataConverterInterface
         private readonly LoggingServiceInterface $loggingService,
         private readonly EntityDefinition $dataDefinition,
         private readonly MappingServiceInterface $mappingService,
-        private readonly MigrationValidationService $validationService,
+        private readonly MigrationEntityValidationService $validationService,
     ) {
     }
 

--- a/src/Migration/Validation/Exception/MigrationValidationException.php
+++ b/src/Migration/Validation/Exception/MigrationValidationException.php
@@ -29,6 +29,8 @@ class MigrationValidationException extends MigrationException
 
     final public const VALIDATION_INVALID_ASSOCIATION = 'SWAG_MIGRATION_VALIDATION__INVALID_ASSOCIATION';
 
+    final public const VALIDATION_ENTITY_FIELD_NOT_FOUND = 'SWAG_MIGRATION_VALIDATION__ENTITY_FIELD_NOT_FOUND';
+
     public static function unexpectedNullValue(string $fieldName): self
     {
         return new self(
@@ -49,33 +51,36 @@ class MigrationValidationException extends MigrationException
         );
     }
 
-    public static function invalidRequiredFieldValue(string $entityName, string $fieldName, string $message): self
+    public static function invalidRequiredFieldValue(string $entityName, string $fieldName, ?\Throwable $previous = null): self
     {
         return new self(
             Response::HTTP_BAD_REQUEST,
             self::VALIDATION_INVALID_REQUIRED_FIELD_VALUE,
             'Invalid value for required field "{{ fieldName }}" in entity "{{ entityName }}": {{ message }}',
-            ['fieldName' => $fieldName, 'entityName' => $entityName, 'message' => $message]
+            ['fieldName' => $fieldName, 'entityName' => $entityName, 'message' => $previous?->getMessage() ?? ''],
+            $previous
         );
     }
 
-    public static function invalidOptionalFieldValue(string $entityName, string $fieldName, string $message): self
+    public static function invalidOptionalFieldValue(string $entityName, string $fieldName, ?\Throwable $previous = null): self
     {
         return new self(
             Response::HTTP_BAD_REQUEST,
             self::VALIDATION_INVALID_OPTIONAL_FIELD_VALUE,
             'Invalid value for optional field "{{ fieldName }}" in entity "{{ entityName }}": {{ message }}',
-            ['fieldName' => $fieldName, 'entityName' => $entityName, 'message' => $message]
+            ['fieldName' => $fieldName, 'entityName' => $entityName, 'message' => $previous?->getMessage() ?? ''],
+            $previous
         );
     }
 
-    public static function invalidTranslation(string $entityName, string $fieldName, string $message): self
+    public static function invalidTranslation(string $entityName, string $fieldName, ?\Throwable $previous = null): self
     {
         return new self(
             Response::HTTP_BAD_REQUEST,
             self::VALIDATION_INVALID_TRANSLATION,
             'Invalid translation for field "{{ fieldName }}" in entity "{{ entityName }}": {{ message }}',
-            ['fieldName' => $fieldName, 'entityName' => $entityName, 'message' => $message]
+            ['fieldName' => $fieldName, 'entityName' => $entityName, 'message' => $previous?->getMessage() ?? ''],
+            $previous
         );
     }
 
@@ -86,6 +91,16 @@ class MigrationValidationException extends MigrationException
             self::VALIDATION_INVALID_ASSOCIATION,
             'Invalid association "{{ fieldName }}" in entity "{{ entityName }}": {{ message }}',
             ['fieldName' => $fieldName, 'entityName' => $entityName, 'message' => $message]
+        );
+    }
+
+    public static function entityFieldNotFound(string $entityName, string $fieldName): self
+    {
+        return new self(
+            Response::HTTP_NOT_FOUND,
+            self::VALIDATION_ENTITY_FIELD_NOT_FOUND,
+            'Field "{{ fieldName }}" not found in entity "{{ entityName }}".',
+            ['fieldName' => $fieldName, 'entityName' => $entityName]
         );
     }
 }

--- a/src/Migration/Validation/MigrationEntityValidationService.php
+++ b/src/Migration/Validation/MigrationEntityValidationService.php
@@ -12,24 +12,14 @@ use Doctrine\DBAL\Exception;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\CompiledFieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use SwagMigrationAssistant\Migration\Logging\Log\Builder\MigrationLogBuilder;
@@ -51,7 +41,7 @@ use Symfony\Contracts\Service\ResetInterface;
  * @internal
  */
 #[Package('fundamentals@after-sales')]
-class MigrationValidationService implements ResetInterface
+class MigrationEntityValidationService implements ResetInterface
 {
     /**
      * @var list<class-string<Field>>
@@ -82,6 +72,7 @@ class MigrationValidationService implements ResetInterface
         private readonly DefinitionInstanceRegistry $definitionRegistry,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly LoggingServiceInterface $loggingService,
+        private readonly MigrationFieldValidationService $fieldValidationService,
         private readonly Connection $connection,
     ) {
     }
@@ -95,7 +86,7 @@ class MigrationValidationService implements ResetInterface
      * @param array<string, mixed>|null $convertedEntity
      * @param array<string, mixed> $sourceData
      *
-     * @throws \Exception|Exception
+     * @throws \Exception
      */
     public function validate(
         MigrationContextInterface $migrationContext,
@@ -126,8 +117,12 @@ class MigrationValidationService implements ResetInterface
             new MigrationPreValidationEvent($validationContext),
         );
 
-        $this->validateEntityStructure($validationContext);
-        $this->validateFieldValues($validationContext);
+        try {
+            $this->validateEntityStructure($validationContext);
+            $this->validateFieldValues($validationContext);
+        } catch (\Throwable $exception) {
+            $this->addExceptionLog($validationContext, $exception);
+        }
 
         $this->eventDispatcher->dispatch(
             new MigrationPostValidationEvent($validationContext),
@@ -178,29 +173,24 @@ class MigrationValidationService implements ResetInterface
 
         $entityDefinition = $validationContext->getEntityDefinition();
         $entityName = $entityDefinition->getEntityName();
+
         $fields = $entityDefinition->getFields();
-
-        $entityExistence = EntityExistence::createForEntity($entityName, ['id' => $id]);
-        $parameters = new WriteParameterBag(
-            $entityDefinition,
-            WriteContext::createFromContext($validationContext->getContext()),
-            '',
-            new WriteCommandQueue(),
-        );
-
         $requiredFields = $this->getRequiredFields($fields, $entityName);
 
         foreach ($convertedData as $fieldName => $value) {
-            $this->validateField(
-                $validationContext,
-                $fields,
-                $fieldName,
-                $value,
-                $id,
-                $entityExistence,
-                $parameters,
-                isset($requiredFields[$fieldName])
-            );
+            try {
+                $this->fieldValidationService->validateField(
+                    $entityName,
+                    $fieldName,
+                    $value,
+                    $validationContext->getContext(),
+                    isset($requiredFields[$fieldName])
+                );
+            } catch (MigrationValidationException $exception) {
+                $this->addValidationExceptionLog($validationContext, $exception, $fieldName, $value, (string) $id);
+            } catch (\Throwable $exception) {
+                $this->addExceptionLog($validationContext, $exception);
+            }
         }
     }
 
@@ -225,166 +215,6 @@ class MigrationValidationService implements ResetInterface
         }
 
         return true;
-    }
-
-    private function validateField(
-        MigrationValidationContext $validationContext,
-        CompiledFieldCollection $fields,
-        string $fieldName,
-        mixed $value,
-        string $id,
-        EntityExistence $existence,
-        WriteParameterBag $parameters,
-        bool $isRequired,
-    ): void {
-        if (!$fields->has($fieldName)) {
-            return;
-        }
-
-        $field = clone $fields->get($fieldName);
-
-        try {
-            if ($field instanceof TranslationsAssociationField) {
-                $this->validateFieldByFieldSerializer($field, $value, $existence, $parameters, $isRequired);
-
-                return;
-            }
-
-            if ($field instanceof ManyToManyAssociationField || $field instanceof OneToManyAssociationField) {
-                $this->validateToManyAssociationStructure($validationContext, $fieldName, $value);
-
-                return;
-            }
-
-            if ($field instanceof ManyToOneAssociationField || $field instanceof OneToOneAssociationField) {
-                $this->validateToOneAssociationStructure($validationContext, $fieldName, $value);
-
-                return;
-            }
-
-            if ($field instanceof AssociationField) {
-                return;
-            }
-
-            $this->validateFieldByFieldSerializer($field, $value, $existence, $parameters, $isRequired);
-        } catch (MigrationValidationException $exception) {
-            $this->addValidationExceptionLog($validationContext, $exception, $fieldName, $value, $id);
-        } catch (\Throwable $exception) {
-            $this->addExceptionLog($validationContext, $exception);
-        }
-    }
-
-    /**
-     * @throws MigrationValidationException|\Exception
-     */
-    private function validateFieldByFieldSerializer(
-        Field $field,
-        mixed $value,
-        EntityExistence $entityExistence,
-        WriteParameterBag $parameters,
-        bool $isRequired,
-    ): void {
-        /**
-         * Replace all flags with Required to force the serializer to validate this field.
-         * AbstractFieldSerializer::requiresValidation() skips validation for fields without Required flag.
-         * The field is cloned before this method is called to avoid mutating the original definition.
-         */
-        $field->setFlags(new Required());
-
-        $keyValue = new KeyValuePair(
-            $field->getPropertyName(),
-            $value,
-            true
-        );
-
-        try {
-            $serializer = $field->getSerializer();
-
-            // Consume the generator to trigger validation. Keys are not needed
-            \iterator_to_array($serializer->encode(
-                $field,
-                $entityExistence,
-                $keyValue,
-                $parameters
-            ), false);
-        } catch (\Throwable $e) {
-            $entityName = $parameters->getDefinition()->getEntityName();
-            $propertyName = $field->getPropertyName();
-
-            if ($field instanceof TranslationsAssociationField) {
-                throw MigrationValidationException::invalidTranslation($entityName, $propertyName, $e->getMessage());
-            }
-
-            if ($isRequired) {
-                throw MigrationValidationException::invalidRequiredFieldValue($entityName, $propertyName, $e->getMessage());
-            }
-
-            throw MigrationValidationException::invalidOptionalFieldValue($entityName, $propertyName, $e->getMessage());
-        }
-    }
-
-    /**
-     * @throws MigrationValidationException
-     */
-    private function validateToManyAssociationStructure(
-        MigrationValidationContext $validationContext,
-        string $fieldName,
-        mixed $value,
-    ): void {
-        $entityName = $validationContext->getEntityDefinition()->getEntityName();
-
-        if (!\is_array($value)) {
-            throw MigrationValidationException::invalidAssociation(
-                $entityName,
-                $fieldName,
-                \sprintf('must be an array, got %s', \get_debug_type($value))
-            );
-        }
-
-        foreach ($value as $index => $entry) {
-            if (!\is_array($entry)) {
-                throw MigrationValidationException::invalidAssociation(
-                    $entityName,
-                    $fieldName . '/' . $index,
-                    \sprintf('entry at index %s must be an array, got %s', $index, \get_debug_type($entry))
-                );
-            }
-
-            if (isset($entry['id']) && !Uuid::isValid($entry['id'])) {
-                throw MigrationValidationException::invalidAssociation(
-                    $entityName,
-                    $fieldName . '/' . $index . '/id',
-                    \sprintf('invalid UUID "%s" at index %s', $entry['id'], $index)
-                );
-            }
-        }
-    }
-
-    /**
-     * @throws MigrationValidationException
-     */
-    private function validateToOneAssociationStructure(
-        MigrationValidationContext $validationContext,
-        string $fieldName,
-        mixed $value,
-    ): void {
-        $entityName = $validationContext->getEntityDefinition()->getEntityName();
-
-        if (!\is_array($value)) {
-            throw MigrationValidationException::invalidAssociation(
-                $entityName,
-                $fieldName,
-                \sprintf('must be an array, got %s', \get_debug_type($value))
-            );
-        }
-
-        if (isset($value['id']) && !Uuid::isValid($value['id'])) {
-            throw MigrationValidationException::invalidAssociation(
-                $entityName,
-                $fieldName . '/id',
-                \sprintf('invalid UUID "%s"', $value['id'])
-            );
-        }
     }
 
     /**

--- a/src/Migration/Validation/MigrationFieldValidationService.php
+++ b/src/Migration/Validation/MigrationFieldValidationService.php
@@ -9,7 +9,14 @@ namespace SwagMigrationAssistant\Migration\Validation;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
@@ -17,8 +24,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use SwagMigrationAssistant\Exception\MigrationException;
+use SwagMigrationAssistant\Migration\Validation\Exception\MigrationValidationException;
 
 /**
  * @internal
@@ -32,29 +39,31 @@ readonly class MigrationFieldValidationService
     }
 
     /**
-     * Validates a field value using the DAL field serializer.
-     *
-     * @throws WriteConstraintViolationException|MigrationException|\Exception if the value is not valid
+     * @throws \Exception|MigrationException
      */
-    public function validateFieldValue(
+    public function validateField(
         string $entityName,
         string $fieldName,
         mixed $value,
         Context $context,
-        ?string $entityId = null,
+        bool $isRequired = true,
     ): void {
+        if (!$this->definitionRegistry->has($entityName)) {
+            throw MigrationException::entityNotExists($entityName, $fieldName);
+        }
+
         $entityDefinition = $this->definitionRegistry->getByEntityName($entityName);
         $fields = $entityDefinition->getFields();
 
         if (!$fields->has($fieldName)) {
-            throw MigrationException::entityFieldNotFound($entityName, $fieldName);
+            throw MigrationValidationException::entityFieldNotFound($entityName, $fieldName);
         }
 
-        $field = $fields->get($fieldName);
+        $field = clone $fields->get($fieldName);
 
-        $entityExistence = EntityExistence::createForEntity(
+        $existence = EntityExistence::createForEntity(
             $entityDefinition->getEntityName(),
-            ['id' => $entityId ?? Uuid::randomHex()],
+            ['id' => Uuid::randomHex()],
         );
 
         $parameters = new WriteParameterBag(
@@ -64,16 +73,171 @@ readonly class MigrationFieldValidationService
             new WriteCommandQueue(),
         );
 
-        $field = clone $field;
+        if ($field instanceof TranslationsAssociationField) {
+            $this->validateTranslationAssociationStructure($field, $value, $entityName);
+
+            return;
+        }
+
+        if ($field instanceof ManyToManyAssociationField || $field instanceof OneToManyAssociationField) {
+            $this->validateToManyAssociationStructure($field, $value, $entityName);
+
+            return;
+        }
+
+        if ($field instanceof ManyToOneAssociationField || $field instanceof OneToOneAssociationField) {
+            $this->validateToOneAssociationStructure($field, $value, $entityName);
+
+            return;
+        }
+
+        if ($field instanceof AssociationField) {
+            return;
+        }
+
+        $this->validateFieldByFieldSerializer(
+            $field,
+            $value,
+            $isRequired,
+            $existence,
+            $parameters,
+        );
+    }
+
+    private function validateFieldByFieldSerializer(
+        Field $field,
+        mixed $value,
+        bool $isRequired,
+        EntityExistence $existence,
+        WriteParameterBag $parameters,
+    ): void {
+        /**
+         * Replace all flags with Required to force the serializer to validate this field.
+         * AbstractFieldSerializer::requiresValidation() skips validation for fields without Required flag.
+         * The field is cloned before this method is called to avoid mutating the original definition.
+         */
         $field->setFlags(new Required());
 
         $keyValue = new KeyValuePair(
             $field->getPropertyName(),
             $value,
-            true,
+            true
         );
 
         $serializer = $field->getSerializer();
-        \iterator_to_array($serializer->encode($field, $entityExistence, $keyValue, $parameters), false);
+
+        try {
+            // Consume the generator to trigger validation. Keys are not needed
+            \iterator_to_array($serializer->encode(
+                $field,
+                $existence,
+                $keyValue,
+                $parameters
+            ), false);
+        } catch (\Throwable $e) {
+            $entityName = $parameters->getDefinition()->getEntityName();
+            $propertyName = $field->getPropertyName();
+
+            if ($field instanceof TranslationsAssociationField) {
+                throw MigrationValidationException::invalidTranslation(
+                    $entityName,
+                    $propertyName,
+                    $e,
+                );
+            }
+
+            if ($isRequired) {
+                throw MigrationValidationException::invalidRequiredFieldValue(
+                    $entityName,
+                    $propertyName,
+                    $e
+                );
+            }
+
+            throw MigrationValidationException::invalidOptionalFieldValue(
+                $entityName,
+                $propertyName,
+                $e
+            );
+        }
+    }
+
+    private function validateToManyAssociationStructure(Field $field, mixed $value, string $entityName): void
+    {
+        if (!\is_array($value)) {
+            throw MigrationValidationException::invalidAssociation(
+                $entityName,
+                $field->getPropertyName(),
+                \sprintf('must be an array, got %s', \get_debug_type($value))
+            );
+        }
+
+        foreach ($value as $index => $entry) {
+            if (!\is_array($entry)) {
+                throw MigrationValidationException::invalidAssociation(
+                    $entityName,
+                    $field->getPropertyName() . '/' . $index,
+                    \sprintf('entry at index %s must be an array, got %s', $index, \get_debug_type($entry))
+                );
+            }
+
+            if (isset($entry['id']) && !Uuid::isValid($entry['id'])) {
+                throw MigrationValidationException::invalidAssociation(
+                    $entityName,
+                    $field->getPropertyName() . '/' . $index . '/id',
+                    \sprintf('invalid UUID "%s" at index %s', $entry['id'], $index)
+                );
+            }
+        }
+    }
+
+    private function validateToOneAssociationStructure(Field $field, mixed $value, string $entityName): void
+    {
+        if (!\is_array($value)) {
+            throw MigrationValidationException::invalidAssociation(
+                $entityName,
+                $field->getPropertyName(),
+                \sprintf('must be an array, got %s', \get_debug_type($value))
+            );
+        }
+
+        if (isset($value['id']) && !Uuid::isValid($value['id'])) {
+            throw MigrationValidationException::invalidAssociation(
+                $entityName,
+                $field->getPropertyName() . '/id',
+                \sprintf('invalid UUID "%s"', $value['id'])
+            );
+        }
+    }
+
+    private function validateTranslationAssociationStructure(TranslationsAssociationField $field, mixed $value, string $entityName): void
+    {
+        if (!\is_array($value)) {
+            throw MigrationValidationException::invalidTranslation(
+                $entityName,
+                $field->getPropertyName(),
+                new \InvalidArgumentException(\sprintf('must be an array, got %s', \get_debug_type($value)))
+            );
+        }
+
+        foreach ($value as $languageId => $translation) {
+            // Language key must be a string (UUID or locale code like 'en-GB')
+            if (!\is_string($languageId) || $languageId === '') {
+                throw MigrationValidationException::invalidTranslation(
+                    $entityName,
+                    $field->getPropertyName(),
+                    new \InvalidArgumentException(\sprintf('language key must be a non-empty string, got %s', \get_debug_type($languageId)))
+                );
+            }
+
+            // Each translation entry must be an array
+            if (!\is_array($translation)) {
+                throw MigrationValidationException::invalidTranslation(
+                    $entityName,
+                    $field->getPropertyName() . '/' . $languageId,
+                    new \InvalidArgumentException(\sprintf('translation entry must be an array, got %s', \get_debug_type($translation)))
+                );
+            }
+        }
     }
 }

--- a/src/Migration/Validation/MigrationFieldValidationService.php
+++ b/src/Migration/Validation/MigrationFieldValidationService.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SwagMigrationAssistant\Migration\Validation;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use SwagMigrationAssistant\Exception\MigrationException;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+readonly class MigrationFieldValidationService
+{
+    public function __construct(
+        private DefinitionInstanceRegistry $definitionRegistry,
+    ) {
+    }
+
+    /**
+     * Validates a field value using the DAL field serializer.
+     *
+     * @throws WriteConstraintViolationException|MigrationException|\Exception if the value is not valid
+     */
+    public function validateFieldValue(
+        string $entityName,
+        string $fieldName,
+        mixed $value,
+        Context $context,
+        ?string $entityId = null,
+    ): void {
+        $entityDefinition = $this->definitionRegistry->getByEntityName($entityName);
+        $fields = $entityDefinition->getFields();
+
+        if (!$fields->has($fieldName)) {
+            throw MigrationException::entityFieldNotFound($entityName, $fieldName);
+        }
+
+        $field = $fields->get($fieldName);
+
+        $entityExistence = EntityExistence::createForEntity(
+            $entityDefinition->getEntityName(),
+            ['id' => $entityId ?? Uuid::randomHex()],
+        );
+
+        $parameters = new WriteParameterBag(
+            $entityDefinition,
+            WriteContext::createFromContext($context),
+            '',
+            new WriteCommandQueue(),
+        );
+
+        $field = clone $field;
+        $field->setFlags(new Required());
+
+        $keyValue = new KeyValuePair(
+            $field->getPropertyName(),
+            $value,
+            true,
+        );
+
+        $serializer = $field->getSerializer();
+        \iterator_to_array($serializer->encode($field, $entityExistence, $keyValue, $parameters), false);
+    }
+}

--- a/src/Resources/app/administration/src/core/service/api/swag-migration.api.service.ts
+++ b/src/Resources/app/administration/src/core/service/api/swag-migration.api.service.ts
@@ -602,4 +602,60 @@ export default class MigrationApiService extends ApiService {
                 return ApiService.handleResponse(response);
             });
     }
+
+    async validateResolution(
+        entityName: string,
+        fieldName: string,
+        fieldValue: unknown,
+        additionalHeaders: AdditionalHeaders = {},
+    ): Promise<{ isValid: boolean; violations: Array<{ message: string; propertyPath?: string }> }> {
+        // @ts-ignore
+        const headers = this.getBasicHeaders(additionalHeaders);
+
+        // @ts-ignore
+        return this.httpClient
+            .post(
+                // @ts-ignore
+                `_action/${this.getApiBasePath()}/error-resolution/validate`,
+                {
+                    entityName,
+                    fieldName,
+                    fieldValue,
+                },
+                {
+                    ...this.basicConfig,
+                    headers,
+                },
+            )
+            .then((response: AxiosResponse) => {
+                return ApiService.handleResponse(response);
+            });
+    }
+
+    async getExampleFieldStructure(
+        entityName: string,
+        fieldName: string,
+        additionalHeaders: AdditionalHeaders = {},
+    ): Promise<{ fieldType: string; example: string | null }> {
+        // @ts-ignore
+        const headers = this.getBasicHeaders(additionalHeaders);
+
+        // @ts-ignore
+        return this.httpClient
+            .post(
+                // @ts-ignore
+                `_action/${this.getApiBasePath()}/error-resolution/example-field-structure`,
+                {
+                    entityName,
+                    fieldName,
+                },
+                {
+                    ...this.basicConfig,
+                    headers,
+                },
+            )
+            .then((response: AxiosResponse) => {
+                return ApiService.handleResponse(response);
+            });
+    }
 }

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar/index.ts
@@ -32,10 +32,6 @@ export default Shopware.Component.wrapComponentConfig({
             type: Object as PropType<Property>,
             required: true,
         },
-        entityName: {
-            type: String,
-            required: true,
-        },
         fieldName: {
             type: String,
             required: true,

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar/index.ts
@@ -16,7 +16,9 @@ export interface SwagMigrationErrorResolutionFieldScalarData {
 export default Shopware.Component.wrapComponentConfig({
     template,
 
-    inject: ['updateFieldValue'],
+    inject: [
+        'updateFieldValue',
+    ],
 
     props: {
         componentType: {
@@ -30,14 +32,28 @@ export default Shopware.Component.wrapComponentConfig({
             type: Object as PropType<Property>,
             required: true,
         },
+        entityName: {
+            type: String,
+            required: true,
+        },
         fieldName: {
             type: String,
             required: true,
+        },
+        error: {
+            type: Object as PropType<{ detail: string }>,
+            required: false,
+            default: null,
         },
         disabled: {
             type: Boolean,
             required: false,
             default: false,
+        },
+        exampleValue: {
+            type: String as PropType<string | null>,
+            required: false,
+            default: null,
         },
     },
 
@@ -50,8 +66,20 @@ export default Shopware.Component.wrapComponentConfig({
     watch: {
         fieldValue: {
             handler() {
+                if (this.componentType === 'switch' && this.fieldValue === null) {
+                    this.fieldValue = false;
+                }
+
                 if (this.updateFieldValue) {
                     this.updateFieldValue(this.fieldValue);
+                }
+            },
+            immediate: true,
+        },
+        exampleValue: {
+            handler(newValue: string | null) {
+                if (this.componentType === 'editor' && newValue !== null && this.fieldValue === null) {
+                    this.fieldValue = newValue;
                 }
             },
             immediate: true,

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar/swag-migration-error-resolution-field-scalar.html.twig
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar/swag-migration-error-resolution-field-scalar.html.twig
@@ -8,6 +8,7 @@
             name="migration-resolution--number"
             :label="fieldName"
             :number-type="numberFieldType"
+            :error="error"
             :disabled="disabled"
         />
     {% endblock %}
@@ -19,6 +20,7 @@
             class="sw-migration-error-resolution-field__textarea"
             name="migration-resolution--textarea"
             :label="fieldName"
+            :error="error"
             :disabled="disabled"
         />
     {% endblock %}
@@ -30,6 +32,7 @@
             class="sw-migration-error-resolution-field__text"
             name="migration-resolution--text"
             :label="fieldName"
+            :error="error"
             :disabled="disabled"
         />
     {% endblock %}
@@ -41,6 +44,7 @@
             class="sw-migration-error-resolution-field__switch"
             name="migration-resolution--switch"
             :label="fieldName"
+            :error="error"
             :disabled="disabled"
         />
     {% endblock %}
@@ -53,6 +57,7 @@
             name="migration-resolution--datepicker"
             date-type="datetime"
             :label="fieldName"
+            :error="error"
             :disabled="disabled"
         />
     {% endblock %}
@@ -63,6 +68,7 @@
             v-model:value="fieldValue"
             class="sw-migration-error-resolution-field__editor"
             name="migration-resolution--code-editor"
+            :error="error"
             :label="fieldName"
         />
     {% endblock %}

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-unhandled/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-unhandled/index.ts
@@ -4,8 +4,7 @@ import template from './swag-migration-error-resolution-field-unhandled.html.twi
  * @private
  */
 export interface SwagMigrationErrorResolutionFieldUnhandledData {
-    fieldValue: string;
-    error: { detail: string } | null;
+    fieldValue: string | null;
 }
 
 /**
@@ -27,12 +26,21 @@ export default Shopware.Component.wrapComponentConfig({
             required: false,
             default: false,
         },
+        error: {
+            type: Object as PropType<{ detail: string }>,
+            required: false,
+            default: null,
+        },
+        exampleValue: {
+            type: String as PropType<string | null>,
+            required: false,
+            default: null,
+        },
     },
 
     data(): SwagMigrationErrorResolutionFieldUnhandledData {
         return {
-            fieldValue: '',
-            error: null,
+            fieldValue: null,
         };
     },
 
@@ -40,35 +48,18 @@ export default Shopware.Component.wrapComponentConfig({
         fieldValue: {
             handler() {
                 if (this.updateFieldValue) {
-                    const parsedValue = this.parseJsonFieldValue();
-
-                    this.updateFieldValue(parsedValue);
+                    this.updateFieldValue(this.fieldValue);
                 }
             },
             immediate: true,
         },
-    },
-
-    methods: {
-        parseJsonFieldValue(): string | number | boolean | null | object | unknown[] {
-            if (!this.fieldValue || typeof this.fieldValue !== 'string') {
-                this.error = null;
-
-                return this.fieldValue;
-            }
-
-            try {
-                const value = JSON.parse(this.fieldValue);
-                this.error = null;
-
-                return value;
-            } catch {
-                this.error = {
-                    detail: this.$tc('swag-migration.index.error-resolution.errors.invalidJsonInput'),
-                };
-
-                return null;
-            }
+        exampleValue: {
+            handler(newValue: string | null) {
+                if (newValue !== null && this.fieldValue === null) {
+                    this.fieldValue = newValue;
+                }
+            },
+            immediate: true,
         },
     },
 });

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-unhandled/swag-migration-error-resolution-field-unhandled.html.twig
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-unhandled/swag-migration-error-resolution-field-unhandled.html.twig
@@ -11,9 +11,6 @@
         <sw-code-editor
             v-model:value="fieldValue"
             :label="fieldName"
-            mode="text"
-            :completer-function="null"
-            :soft-wraps="true"
             :error="error"
         />
     </div>

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field/index.ts
@@ -3,6 +3,14 @@ import template from './swag-migration-error-resolution-field.html.twig';
 import './swag-migration-error-resolution-field.scss';
 import type { ErrorResolutionTableData } from '../../swag-migration-error-resolution-step';
 import { MIGRATION_ERROR_RESOLUTION_SERVICE } from '../../../../service/swag-migration-error-resolution.service';
+import { MIGRATION_API_SERVICE } from '../../../../../../core/service/api/swag-migration.api.service';
+
+/**
+ * @private
+ */
+export interface SwagMigrationErrorResolutionFieldData {
+    exampleValue: string | null;
+}
 
 /**
  * @private
@@ -13,6 +21,11 @@ export default Shopware.Component.wrapComponentConfig({
 
     inject: [
         MIGRATION_ERROR_RESOLUTION_SERVICE,
+        MIGRATION_API_SERVICE,
+    ],
+
+    mixins: [
+        Shopware.Mixin.getByName('notification'),
     ],
 
     props: {
@@ -20,11 +33,26 @@ export default Shopware.Component.wrapComponentConfig({
             type: Object as PropType<ErrorResolutionTableData>,
             required: true,
         },
+        error: {
+            type: Object as PropType<{ detail: string }>,
+            required: false,
+            default: null,
+        },
         disabled: {
             type: Boolean,
             required: false,
             default: false,
         },
+    },
+
+    data(): SwagMigrationErrorResolutionFieldData {
+        return {
+            exampleValue: null,
+        };
+    },
+
+    async created() {
+        await this.fetchExampleValue();
     },
 
     computed: {
@@ -46,6 +74,31 @@ export default Shopware.Component.wrapComponentConfig({
 
         fieldType(): string | null {
             return this.swagMigrationErrorResolutionService.getFieldType(this.log.entityName, this.log.fieldName);
+        },
+
+        shouldFetchExample(): boolean {
+            return this.isUnhandledField || this.fieldType === 'editor';
+        },
+    },
+
+    methods: {
+        async fetchExampleValue(): Promise<void> {
+            if (!this.shouldFetchExample) {
+                return;
+            }
+
+            try {
+                const response = await this.migrationApiService.getExampleFieldStructure(
+                    this.log.entityName,
+                    this.log.fieldName,
+                );
+
+                this.exampleValue = response?.example ?? null;
+            } catch {
+                this.createNotificationError({
+                    message: this.$tc('swag-migration.index.error-resolution.errors.fetchExampleFailed'),
+                });
+            }
         },
     },
 });

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field/swag-migration-error-resolution-field.html.twig
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field/swag-migration-error-resolution-field.html.twig
@@ -5,6 +5,8 @@
                 v-if="isUnhandledField"
                 :field-name="log?.fieldName"
                 :disabled="disabled"
+                :error="error"
+                :example-value="exampleValue"
             />
         {% endblock %}
 
@@ -12,9 +14,12 @@
             <swag-migration-error-resolution-field-scalar
                 v-else-if="isScalarField"
                 :component-type="fieldType"
+                :entity-name="log?.entityName"
                 :field-name="log?.fieldName"
                 :entity-field="entityField"
+                :error="error"
                 :disabled="disabled"
+                :example-value="exampleValue"
             />
         {% endblock %}
 

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
@@ -249,21 +249,24 @@ export default Shopware.Component.wrapComponentConfig({
                     this.createNotificationError({
                         message: this.$tc('swag-migration.index.error-resolution.errors.validationFailed'),
                     });
-
-                    return false;
+                    return null;
                 });
 
-            if (serializationError?.valid === true) {
-                return true;
-            }
-
-            if (!serializationError?.violations?.length) {
+            if (!serializationError) {
                 return false;
             }
 
-            this.fieldError = {
-                detail: serializationError.violations.at(0)?.message,
-            };
+            if (serializationError.valid === true) {
+                return true;
+            }
+
+            const message = serializationError.violations?.at(0)?.message;
+
+            if (!message) {
+                return false;
+            }
+
+            this.fieldError = { detail: message };
 
             return false;
         },

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
@@ -46,6 +46,7 @@ export interface SwagMigrationErrorResolutionModalData {
     loading: boolean;
     submitLoading: boolean;
     fieldValue: string[] | string | boolean | number | null;
+    fieldError: { detail: string } | null;
     migrationStore: MigrationStore;
 }
 
@@ -89,6 +90,7 @@ export default Shopware.Component.wrapComponentConfig({
             loading: false,
             submitLoading: false,
             fieldValue: null,
+            fieldError: null,
             migrationStore: Shopware.Store.get(MIGRATION_STORE_ID),
         };
     },
@@ -179,21 +181,13 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         async onSubmitResolution() {
-            const validationError = this.swagMigrationErrorResolutionService.validateFieldValue(
-                this.selectedLog.entityName,
-                this.selectedLog.fieldName,
-                this.fieldValue,
-            );
+            this.submitLoading = true;
+            this.fieldError = null;
 
-            if (validationError) {
-                this.createNotificationError({
-                    message: this.$tc(`swag-migration.index.error-resolution.errors.${validationError}`),
-                });
-
+            if (!(await this.validateResolution())) {
+                this.submitLoading = false;
                 return;
             }
-
-            this.submitLoading = true;
 
             try {
                 const entityIds = await this.collectEntityIdsForSubmission();
@@ -221,6 +215,57 @@ export default Shopware.Component.wrapComponentConfig({
             } finally {
                 this.submitLoading = false;
             }
+        },
+
+        async validateResolution(): Promise<boolean> {
+            const validationError = this.swagMigrationErrorResolutionService.validateFieldValue(
+                this.selectedLog.entityName,
+                this.selectedLog.fieldName,
+                this.fieldValue,
+            );
+
+            if (validationError) {
+                this.createNotificationError({
+                    message: this.$tc(`swag-migration.index.error-resolution.errors.${validationError}`),
+                });
+
+                return false;
+            }
+
+            // skip backend validation for to many associations as they use id arrays
+            // which are not compatible with the dal serializer format
+            if (
+                this.swagMigrationErrorResolutionService.isToManyAssociationField(
+                    this.selectedLog.entityName,
+                    this.selectedLog.fieldName,
+                )
+            ) {
+                return true;
+            }
+
+            const serializationError = await this.migrationApiService
+                .validateResolution(this.selectedLog.entityName, this.selectedLog.fieldName, this.fieldValue)
+                .catch(() => {
+                    this.createNotificationError({
+                        message: this.$tc('swag-migration.index.error-resolution.errors.validationFailed'),
+                    });
+
+                    return false;
+                });
+
+            if (serializationError?.valid === true) {
+                return true;
+            }
+
+            if (!serializationError?.violations?.length) {
+                return false;
+            }
+
+            this.fieldError = {
+                detail: serializationError.violations.at(0)?.message,
+            };
+
+            return false;
         },
 
         async collectEntityIdsForSubmission(): Promise<string[]> {

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/swag-migration-error-resolution-modal.html.twig
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/swag-migration-error-resolution-modal.html.twig
@@ -99,6 +99,7 @@
                         <div v-if="resolvingComponent === 'DEFAULT'" class="swag-migration-error-resolution-modal__right-content-default">
                             <swag-migration-error-resolution-field
                                 :log="selectedLog"
+                                :error="fieldError"
                                 :disabled="loading || selectedLogIds.length === 0"
                             />
 

--- a/src/Resources/app/administration/src/module/swag-migration/snippet/de.json
+++ b/src/Resources/app/administration/src/module/swag-migration/snippet/de.json
@@ -650,6 +650,8 @@
           "noEntityIdsFound": "Keine gültigen Entitäts-IDs in den ausgewählten Log-Einträgen gefunden.",
           "fetchFilterDataFailed": "Das Abrufen der Filterdaten ist fehlgeschlagen.",
           "fetchExistingFixesFailed": "Das Abrufen vorhandener Korrekturen ist fehlgeschlagen.",
+          "fetchExampleFailed": "Beispieldaten konnten nicht abgerufen werden.",
+          "validationFailed": "Validierung fehlgeschlagen.",
           "invalidJsonInput": "Diese Eingabe ist kein gültiges JSON.",
           "resetResolutionFailed": "Fehler beim Zurücksetzen der Fehlerbehebung."
         },

--- a/src/Resources/app/administration/src/module/swag-migration/snippet/en.json
+++ b/src/Resources/app/administration/src/module/swag-migration/snippet/en.json
@@ -502,7 +502,9 @@
           "fetchFilterDataFailed": "Failed fetching filter data.",
           "fetchExistingFixesFailed": "Failed fetching existing fixes.",
           "invalidJsonInput": "This input is not valid JSON.",
-          "resetResolutionFailed": "Failed resetting error resolution."
+          "resetResolutionFailed": "Failed resetting error resolution.",
+          "fetchExampleFailed": "Failed fetching example data.",
+          "validationFailed": "Validation failed."
         },
         "step": {
           "continue-modal": {

--- a/tests/Jest/src/core/service/api/swag-migration.api.service.spec.js
+++ b/tests/Jest/src/core/service/api/swag-migration.api.service.spec.js
@@ -376,4 +376,39 @@ describe('src/core/service/api/swag-migration.api.service', () => {
         expect(clientMock.history.post[0].data).toBe(JSON.stringify(data));
         expect(clientMock.history.post[0].headers['test-header']).toBe('test-value');
     });
+
+    it('should validate resolution', async () => {
+        const { migrationApiService, clientMock } = createMigrationApiService();
+
+        const data = {
+            entityName: 'product',
+            fieldName: 'name',
+            fieldValue: 'New Product Name',
+        };
+
+        await migrationApiService.validateResolution(data.entityName, data.fieldName, data.fieldValue, {
+            'test-header': 'test-value',
+        });
+
+        expect(clientMock.history.post[0].url).toBe('_action/migration/error-resolution/validate');
+        expect(clientMock.history.post[0].data).toBe(JSON.stringify(data));
+        expect(clientMock.history.post[0].headers['test-header']).toBe('test-value');
+    });
+
+    it('should get example field structure', async () => {
+        const { migrationApiService, clientMock } = createMigrationApiService();
+
+        const data = {
+            entityName: 'product',
+            fieldName: 'name',
+        };
+
+        await migrationApiService.getExampleFieldStructure(data.entityName, data.fieldName, {
+            'test-header': 'test-value',
+        });
+
+        expect(clientMock.history.post[0].url).toBe('_action/migration/error-resolution/example-field-structure');
+        expect(clientMock.history.post[0].data).toBe(JSON.stringify(data));
+        expect(clientMock.history.post[0].headers['test-header']).toBe('test-value');
+    });
 });

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar.spec.js
@@ -10,6 +10,7 @@ const updateFieldValueMock = jest.fn();
 
 const defaultProps = {
     componentType: 'text',
+    entityNAme: 'customer',
     entityField: {
         entity: 'customer',
         type: 'string',
@@ -174,5 +175,43 @@ describe('src/module/swag-migration/component/swag-migration-error-resolution/sw
         ).toBeUndefined();
         await wrapper.setProps({ disabled: true });
         expect(wrapper.find('.sw-migration-error-resolution-field__datepicker input').attributes('disabled')).toBeDefined();
+    });
+
+    it('should init bool field value for switch component', async () => {
+        const props = {
+            ...defaultProps,
+            componentType: 'switch',
+            entityField: {
+                entity: 'customer',
+                type: 'bool',
+            },
+            fieldName: 'active',
+        };
+
+        const wrapper = await createWrapper(props);
+
+        expect(wrapper.vm.fieldValue).toBe(false);
+        expect(wrapper.find('.sw-migration-error-resolution-field__switch input').element.checked).toBe(false);
+    });
+
+    it('should init example value when set', async () => {
+        const props = {
+            ...defaultProps,
+            componentType: 'editor',
+            entityField: {
+                entity: 'product',
+                type: 'string',
+            },
+            fieldName: 'price',
+        };
+
+        const wrapper = await createWrapper(props);
+        expect(wrapper.find('.sw-migration-error-resolution-field__editor').exists()).toBe(true);
+
+        expect(wrapper.vm.fieldValue).toBeNull();
+
+        const example = 'Sample example value';
+        await wrapper.setProps({ exampleValue: example });
+        expect(wrapper.vm.fieldValue).toBe(example);
     });
 });

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar.spec.js
@@ -10,7 +10,7 @@ const updateFieldValueMock = jest.fn();
 
 const defaultProps = {
     componentType: 'text',
-    entityNAme: 'customer',
+    entityName: 'customer',
     entityField: {
         entity: 'customer',
         type: 'string',

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-unhandled.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-unhandled.spec.js
@@ -23,9 +23,9 @@ async function createWrapper(props = defaultProps) {
             stubs: {
                 'sw-code-editor': await wrapTestComponent('sw-code-editor'),
                 'sw-base-field': await wrapTestComponent('sw-base-field'),
+                'sw-field-error': await wrapTestComponent('sw-field-error'),
                 'sw-inheritance-switch': true,
                 'sw-ai-copilot-badge': true,
-                'sw-field-error': true,
                 'sw-circle-icon': true,
                 'sw-help-text': true,
                 'mt-banner': true,
@@ -71,113 +71,38 @@ describe('src/module/swag-migration/component/swag-migration-error-resolution/sw
         const wrapper = await createWrapper();
         await flushPromises();
 
-        expect(wrapper.find('.sw-code-editor__editor').attributes('content')).toBe('');
-        expect(updateFieldValueMock).toHaveBeenCalledWith('');
-    });
-
-    it.each([
-        { name: 'string', value: '"test string"', expected: 'test string' },
-        { name: 'number', value: '123', expected: 123 },
-        { name: 'boolean', value: 'true', expected: true },
-        { name: 'null', value: 'null', expected: null },
-        { name: 'object', value: '{"key": "value"}', expected: { key: 'value' } },
-        {
-            name: 'array',
-            value: '[1, 2, 3]',
-            expected: [
-                1,
-                2,
-                3,
-            ],
-        },
-    ])('should parse and publish JSON values: $name', async ({ value, expected }) => {
-        const wrapper = await createWrapper();
-        await flushPromises();
-        jest.clearAllMocks();
-
-        await wrapper.setData({ fieldValue: value });
-        await flushPromises();
-
-        expect(updateFieldValueMock).toHaveBeenCalledWith(expected);
-    });
-
-    it.each([
-        {
-            name: 'trailing comma in object',
-            value: '{"key": "value",}',
-        },
-        {
-            name: 'trailing comma in array',
-            value: '[1, 2, 3,]',
-        },
-        {
-            name: 'nested trailing commas',
-            value: '{"outer": {"inner": "value",},}',
-        },
-    ])('should return null and set error for trailing commas: $name', async ({ value }) => {
-        const wrapper = await createWrapper();
-        await flushPromises();
-        jest.clearAllMocks();
-
-        await wrapper.setData({ fieldValue: value });
-        await flushPromises();
-
+        expect(wrapper.find('.sw-code-editor__editor').attributes('content')).toBeUndefined();
         expect(updateFieldValueMock).toHaveBeenCalledWith(null);
-        expect(wrapper.vm.error).not.toBeNull();
-        expect(wrapper.vm.error.detail).toBeDefined();
     });
 
-    it.each([
-        {
-            name: 'invalid JSON',
-            value: 'not json',
-        },
-        {
-            name: 'incomplete object',
-            value: '{"key": ',
-        },
-        {
-            name: 'single quotes',
-            value: "{'key': 'value'}",
-        },
-    ])('should return null and set error for invalid JSON: $name', async ({ value }) => {
-        const wrapper = await createWrapper();
-        await flushPromises();
-        jest.clearAllMocks();
-
-        await wrapper.setData({ fieldValue: value });
-        await flushPromises();
-
-        expect(updateFieldValueMock).toHaveBeenCalledWith(null);
-        expect(wrapper.vm.error).not.toBeNull();
-        expect(wrapper.vm.error.detail).toBeDefined();
-    });
-
-    it('should trim whitespace from JSON string', async () => {
-        const wrapper = await createWrapper();
-        await flushPromises();
-        jest.clearAllMocks();
-
-        await wrapper.setData({ fieldValue: '  {"key": "value"}  ' });
-        await flushPromises();
-
-        expect(updateFieldValueMock).toHaveBeenCalledWith({ key: 'value' });
-        expect(wrapper.vm.error).toBeNull();
-    });
-
-    it('should clear error when valid JSON is entered after invalid JSON', async () => {
+    it('should display error message when passed', async () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({ fieldValue: 'invalid json' });
-        await flushPromises();
-        expect(wrapper.vm.error).not.toBeNull();
+        expect(wrapper.find('.sw-field__error').exists()).toBe(false);
 
-        jest.clearAllMocks();
-        await wrapper.setData({ fieldValue: '{"valid": "json"}' });
+        const message = 'This is an error message';
+        await wrapper.setProps({
+            error: {
+                detail: message,
+            },
+        });
+
+        expect(wrapper.find('.sw-field__error').exists()).toBe(true);
+        expect(wrapper.find('.sw-field__error').text()).toBe(message);
+    });
+
+    it('should init with example value when set', async () => {
+        const wrapper = await createWrapper();
         await flushPromises();
 
-        expect(wrapper.vm.error).toBeNull();
-        expect(updateFieldValueMock).toHaveBeenCalledWith({ valid: 'json' });
+        expect(wrapper.find('.sw-code-editor__editor').attributes('content')).toBeUndefined();
+
+        const exampleValue = 'example content';
+        await wrapper.setProps({
+            exampleValue: exampleValue,
+        });
+
+        expect(wrapper.find('.sw-code-editor__editor').attributes('content')).toBe(exampleValue);
     });
 });

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field.spec.js
@@ -7,6 +7,14 @@ import SwagMigrationErrorResolutionService from 'SwagMigrationAssistant/module/s
 
 Shopware.Component.register('swag-migration-error-resolution-field', () => SwagMigrationErrorResolutionField);
 
+const migrationApiServiceMock = {
+    getExampleFieldStructure: jest.fn().mockResolvedValue(
+        Promise.resolve({
+            example: 'Example Value',
+        }),
+    ),
+};
+
 const defaultProps = {
     log: {
         count: 10,
@@ -30,12 +38,17 @@ async function createWrapper(props = defaultProps) {
             },
             provide: {
                 swagMigrationErrorResolutionService: new SwagMigrationErrorResolutionService(),
+                migrationApiService: migrationApiServiceMock,
             },
         },
     });
 }
 
 describe('src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field', () => {
+    beforeEach(() => {
+        Shopware.Store.get('notification').$reset();
+    });
+
     it('should display unhandled component & pass data', async () => {
         const props = {
             ...defaultProps,
@@ -48,12 +61,16 @@ describe('src/module/swag-migration/component/swag-migration-error-resolution/sw
         };
 
         const wrapper = await createWrapper(props);
+        await flushPromises();
+
+        expect(migrationApiServiceMock.getExampleFieldStructure).toHaveBeenCalled();
 
         const field = wrapper.find('swag-migration-error-resolution-field-unhandled-stub');
 
         expect(field.exists()).toBe(true);
         expect(field.attributes('disabled')).toBe(String(props.disabled));
         expect(field.attributes('field-name')).toBe(props.log.fieldName);
+        expect(field.attributes('example-value')).toBe('Example Value');
     });
 
     it('should display scalar component & pass data', async () => {
@@ -68,6 +85,9 @@ describe('src/module/swag-migration/component/swag-migration-error-resolution/sw
         };
 
         const wrapper = await createWrapper(props);
+        await flushPromises();
+
+        expect(migrationApiServiceMock.getExampleFieldStructure).not.toHaveBeenCalled();
 
         const field = wrapper.find('swag-migration-error-resolution-field-scalar-stub');
 
@@ -89,11 +109,60 @@ describe('src/module/swag-migration/component/swag-migration-error-resolution/sw
         };
 
         const wrapper = await createWrapper(props);
+        await flushPromises();
+
+        expect(migrationApiServiceMock.getExampleFieldStructure).not.toHaveBeenCalled();
 
         const field = wrapper.find('swag-migration-error-resolution-field-relation-stub');
 
         expect(field.exists()).toBe(true);
         expect(field.attributes('disabled')).toBe(String(props.disabled));
         expect(field.attributes('field-name')).toBe(props.log.fieldName);
+    });
+
+    it('should fetch example field value', async () => {
+        const wrapper = await createWrapper({
+            ...defaultProps,
+            log: {
+                ...defaultProps.log,
+                entityName: 'product',
+                fieldName: 'price',
+            },
+        });
+        await flushPromises();
+
+        expect(migrationApiServiceMock.getExampleFieldStructure).toHaveBeenCalled();
+
+        expect(wrapper.find('swag-migration-error-resolution-field-scalar-stub').exists()).toBe(true);
+        expect(wrapper.find('swag-migration-error-resolution-field-scalar-stub').attributes('example-value')).toBe(
+            'Example Value',
+        );
+    });
+
+    it('should display error notification on fetch failure', async () => {
+        migrationApiServiceMock.getExampleFieldStructure.mockRejectedValueOnce(new Error('Fetch failed'));
+
+        await createWrapper({
+            ...defaultProps,
+            log: {
+                ...defaultProps.log,
+                entityName: 'product',
+                fieldName: 'price',
+            },
+        });
+        await flushPromises();
+
+        expect(migrationApiServiceMock.getExampleFieldStructure).toHaveBeenCalled();
+
+        const notifications = Object.values(Shopware.Store.get('notification').notifications);
+
+        expect(notifications).toHaveLength(1);
+        expect(notifications).toStrictEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    message: 'swag-migration.index.error-resolution.errors.fetchExampleFailed',
+                }),
+            ]),
+        );
     });
 });

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
@@ -60,6 +60,7 @@ const defaultProps = {
 };
 
 const migrationApiServiceMock = {
+    validateResolution: jest.fn(() => Promise.resolve({ valid: true })),
     getAllLogIds: jest.fn(() =>
         Promise.resolve({
             ids: logMocks.map((log) => log.id),
@@ -545,6 +546,122 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
     });
 
     describe('create resolution fix', () => {
+        it('should not call backend validation when resolving to-many association fields', async () => {
+            const wrapper = await createWrapper({
+                ...defaultProps,
+                selectedLog: {
+                    ...fixtureLogGroups.at(1),
+                    entityName: 'product',
+                    fieldName: 'categories',
+                },
+            });
+            await flushPromises();
+
+            await wrapper.find('.sw-data-grid__row--1 .mt-field--checkbox input').setChecked(true);
+            await flushPromises();
+
+            const relationField = wrapper.findComponent({ name: 'swag-migration-error-resolution-field-relation' });
+            await relationField.setData({
+                fieldValue: [
+                    'category-id-1',
+                    'category-id-2',
+                ],
+            });
+            await flushPromises();
+
+            await wrapper.find('.swag-migration-error-resolution-modal__right-content-button').trigger('click');
+            await flushPromises();
+
+            expect(migrationApiServiceMock.validateResolution).not.toHaveBeenCalled();
+        });
+
+        it('should save fix when backend validation passes', async () => {
+            migrationApiServiceMock.validateResolution.mockResolvedValueOnce({ valid: true, violations: [] });
+
+            const wrapper = await createWrapper({
+                ...defaultProps,
+                selectedLog: {
+                    ...fixtureLogGroups.at(1),
+                    entityName: 'media',
+                    fieldName: 'title',
+                },
+            });
+            await flushPromises();
+
+            await wrapper.find('.sw-data-grid__row--1 .mt-field--checkbox input').setChecked(true);
+            await flushPromises();
+
+            const inputField = wrapper.find('.swag-migration-error-resolution-field-scalar input');
+            await inputField.setValue('Valid Title');
+            await flushPromises();
+
+            await wrapper.find('.swag-migration-error-resolution-modal__right-content-button').trigger('click');
+            await flushPromises();
+
+            expect(migrationApiServiceMock.validateResolution).toHaveBeenCalledWith('media', 'title', 'Valid Title');
+            expect(wrapper.vm.fieldError).toBeNull();
+            expect(migrationFixRepositoryMock.saveAll).toHaveBeenCalled();
+        });
+
+        it('should not save fix when backend validation fails without message', async () => {
+            migrationApiServiceMock.validateResolution.mockResolvedValueOnce({ valid: false, violations: [] });
+
+            const wrapper = await createWrapper({
+                ...defaultProps,
+                selectedLog: {
+                    ...fixtureLogGroups.at(1),
+                    entityName: 'media',
+                    fieldName: 'title',
+                },
+            });
+            await flushPromises();
+
+            await wrapper.find('.sw-data-grid__row--1 .mt-field--checkbox input').setChecked(true);
+            await flushPromises();
+
+            const inputField = wrapper.find('.swag-migration-error-resolution-field-scalar input');
+            await inputField.setValue('Invalid Value');
+            await flushPromises();
+
+            await wrapper.find('.swag-migration-error-resolution-modal__right-content-button').trigger('click');
+            await flushPromises();
+
+            expect(migrationApiServiceMock.validateResolution).toHaveBeenCalledWith('media', 'title', 'Invalid Value');
+            expect(wrapper.vm.fieldError).toBeNull();
+            expect(migrationFixRepositoryMock.saveAll).not.toHaveBeenCalled();
+        });
+
+        it('should display field error when backend validation fails with message', async () => {
+            migrationApiServiceMock.validateResolution.mockResolvedValueOnce({
+                valid: false,
+                violations: [{ message: 'This value is invalid.' }],
+            });
+
+            const wrapper = await createWrapper({
+                ...defaultProps,
+                selectedLog: {
+                    ...fixtureLogGroups.at(1),
+                    entityName: 'media',
+                    fieldName: 'title',
+                },
+            });
+            await flushPromises();
+
+            await wrapper.find('.sw-data-grid__row--1 .mt-field--checkbox input').setChecked(true);
+            await flushPromises();
+
+            const inputField = wrapper.find('.swag-migration-error-resolution-field-scalar input');
+            await inputField.setValue('Invalid Value');
+            await flushPromises();
+
+            await wrapper.find('.swag-migration-error-resolution-modal__right-content-button').trigger('click');
+            await flushPromises();
+
+            expect(migrationApiServiceMock.validateResolution).toHaveBeenCalledWith('media', 'title', 'Invalid Value');
+            expect(wrapper.vm.fieldError).toStrictEqual({ detail: 'This value is invalid.' });
+            expect(migrationFixRepositoryMock.saveAll).not.toHaveBeenCalled();
+        });
+
         it.each(Object.keys(ERROR_CODE_COMPONENT_MAPPING).map((code) => ({ code })))(
             'should render default resolve component for defined codes: $code',
             async ({ code }) => {

--- a/tests/Migration/Services/MigrationDataConverterTest.php
+++ b/tests/Migration/Services/MigrationDataConverterTest.php
@@ -19,7 +19,7 @@ use SwagMigrationAssistant\Migration\Mapping\MappingServiceInterface;
 use SwagMigrationAssistant\Migration\Media\MediaFileServiceInterface;
 use SwagMigrationAssistant\Migration\MigrationContextInterface;
 use SwagMigrationAssistant\Migration\Service\MigrationDataConverter;
-use SwagMigrationAssistant\Migration\Validation\MigrationValidationService;
+use SwagMigrationAssistant\Migration\Validation\MigrationEntityValidationService;
 use SwagMigrationAssistant\Test\Mock\DataSet\DataSetMock;
 use SwagMigrationAssistant\Test\Mock\Migration\Logging\DummyLoggingService;
 
@@ -60,7 +60,7 @@ class MigrationDataConverterTest extends TestCase
         ?LoggingServiceInterface $loggingService = null,
         ?EntityDefinition $dataDefinition = null,
         ?MappingServiceInterface $mappingService = null,
-        ?MigrationValidationService $validationService = null,
+        ?MigrationEntityValidationService $validationService = null,
     ): MigrationDataConverter {
         if ($entityWriter === null) {
             $entityWriter = $this->createMock(EntityWriter::class);
@@ -87,7 +87,7 @@ class MigrationDataConverterTest extends TestCase
         }
 
         if ($validationService === null) {
-            $validationService = $this->createMock(MigrationValidationService::class);
+            $validationService = $this->createMock(MigrationEntityValidationService::class);
         }
 
         return new MigrationDataConverter(

--- a/tests/MigrationServicesTrait.php
+++ b/tests/MigrationServicesTrait.php
@@ -54,7 +54,8 @@ use SwagMigrationAssistant\Migration\Service\MigrationDataConverter;
 use SwagMigrationAssistant\Migration\Service\MigrationDataConverterInterface;
 use SwagMigrationAssistant\Migration\Service\MigrationDataFetcher;
 use SwagMigrationAssistant\Migration\Service\MigrationDataFetcherInterface;
-use SwagMigrationAssistant\Migration\Validation\MigrationValidationService;
+use SwagMigrationAssistant\Migration\Validation\MigrationEntityValidationService;
+use SwagMigrationAssistant\Migration\Validation\MigrationFieldValidationService;
 use SwagMigrationAssistant\Profile\Shopware\Gateway\Api\Reader\EnvironmentReader;
 use SwagMigrationAssistant\Profile\Shopware\Gateway\Api\Reader\TableCountReader;
 use SwagMigrationAssistant\Profile\Shopware\Gateway\Api\Reader\TableReader;
@@ -208,10 +209,11 @@ trait MigrationServicesTrait
             )
         );
 
-        $validationService = new MigrationValidationService(
+        $validationService = new MigrationEntityValidationService(
             $this->getContainer()->get(DefinitionInstanceRegistry::class),
             $this->getContainer()->get('event_dispatcher'),
             $loggingService,
+            $this->getContainer()->get(MigrationFieldValidationService::class),
             $this->getContainer()->get(Connection::class),
         );
 

--- a/tests/integration/Migration/Controller/ErrorResolutionControllerTest.php
+++ b/tests/integration/Migration/Controller/ErrorResolutionControllerTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use SwagMigrationAssistant\Controller\ErrorResolutionController;
 use SwagMigrationAssistant\Exception\MigrationException;
+use SwagMigrationAssistant\Migration\Validation\Exception\MigrationValidationException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -62,7 +63,7 @@ class ErrorResolutionControllerTest extends TestCase
 
     public function testGetFieldStructureUnknownField(): void
     {
-        static::expectExceptionObject(MigrationException::entityFieldNotFound('product', 'unknownField'));
+        static::expectExceptionObject(MigrationValidationException::entityFieldNotFound('product', 'unknownField'));
 
         $request = new Request([], [
             'entityName' => 'product',

--- a/tests/integration/Migration/Controller/ErrorResolutionControllerTest.php
+++ b/tests/integration/Migration/Controller/ErrorResolutionControllerTest.php
@@ -1,0 +1,326 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace integration\Migration\Controller;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use SwagMigrationAssistant\Controller\ErrorResolutionController;
+use SwagMigrationAssistant\Exception\MigrationException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(ErrorResolutionController::class)]
+class ErrorResolutionControllerTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private ErrorResolutionController $errorResolutionController;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->errorResolutionController = static::getContainer()->get(ErrorResolutionController::class);
+    }
+
+    public function testGetFieldStructureUnsetEntityName(): void
+    {
+        static::expectExceptionObject(MigrationException::missingRequestParameter('entityName'));
+
+        $request = new Request([], [
+            'fieldName' => 'name',
+        ]);
+
+        $this->errorResolutionController->getExampleFieldStructure($request);
+    }
+
+    public function testGetFieldStructureUnsetFieldName(): void
+    {
+        static::expectExceptionObject(MigrationException::missingRequestParameter('fieldName'));
+
+        $request = new Request([], [
+            'entityName' => 'product',
+        ]);
+
+        $this->errorResolutionController->getExampleFieldStructure($request);
+    }
+
+    public function testGetFieldStructureUnknownField(): void
+    {
+        static::expectExceptionObject(MigrationException::entityFieldNotFound('product', 'unknownField'));
+
+        $request = new Request([], [
+            'entityName' => 'product',
+            'fieldName' => 'unknownField',
+        ]);
+
+        $this->errorResolutionController->getExampleFieldStructure($request);
+    }
+
+    /**
+     * @param array<string, string> $expected
+     */
+    #[DataProvider('fieldStructureProvider')]
+    public function testGetFieldStructureProduct(string $entityName, string $fieldName, array $expected): void
+    {
+        $request = new Request([], [
+            'entityName' => $entityName,
+            'fieldName' => $fieldName,
+        ]);
+
+        $response = $this->errorResolutionController->getExampleFieldStructure($request);
+        $responseData = $this->jsonResponseToArray($response);
+
+        static::assertArrayHasKey('fieldType', $responseData);
+        static::assertArrayHasKey('example', $responseData);
+
+        static::assertSame($expected['fieldType'], $responseData['fieldType']);
+        static::assertSame($expected['example'], $responseData['example']);
+    }
+
+    public static function fieldStructureProvider(): \Generator
+    {
+        yield 'product name field' => [
+            'entityName' => 'product',
+            'fieldName' => 'name',
+            'expected' => [
+                'fieldType' => 'TranslatedField',
+                'example' => '"[string]"',
+            ],
+        ];
+
+        yield 'product availableStock field' => [
+            'entityName' => 'product',
+            'fieldName' => 'availableStock',
+            'expected' => [
+                'fieldType' => 'IntField',
+                'example' => '0',
+            ],
+        ];
+
+        yield 'product price field' => [
+            'entityName' => 'product',
+            'fieldName' => 'price',
+            'expected' => [
+                'fieldType' => 'PriceField',
+                'example' => \json_encode([
+                    [
+                        'currencyId' => '[uuid]',
+                        'gross' => 0.1,
+                        'net' => 0.1,
+                        'linked' => false,
+                    ],
+                ], \JSON_PRETTY_PRINT),
+            ],
+        ];
+
+        yield 'product variant listing config' => [
+            'entityName' => 'product',
+            'fieldName' => 'variantListingConfig',
+            'expected' => [
+                'fieldType' => 'VariantListingConfigField',
+                'example' => \json_encode([
+                    'displayParent' => false,
+                    'mainVariantId' => '[uuid]',
+                    'configuratorGroupConfig' => [],
+                ], \JSON_PRETTY_PRINT),
+            ],
+        ];
+    }
+
+    public function testValidateResolutionUnsetEntityName(): void
+    {
+        static::expectExceptionObject(MigrationException::missingRequestParameter('entityName'));
+
+        $request = new Request([], [
+            'fieldName' => 'name',
+        ]);
+
+        $this->errorResolutionController->validateResolution(
+            $request,
+            Context::createDefaultContext()
+        );
+    }
+
+    public function testValidateResolutionUnsetFieldName(): void
+    {
+        static::expectExceptionObject(MigrationException::missingRequestParameter('fieldName'));
+
+        $request = new Request([], [
+            'entityName' => 'product',
+        ]);
+
+        $this->errorResolutionController->validateResolution(
+            $request,
+            Context::createDefaultContext()
+        );
+    }
+
+    /**
+     * @param string|list<string>|null $fieldValue
+     */
+    #[DataProvider('invalidResolutionProvider')]
+    public function testValidateResolutionInvalidRequest(string|array|null $fieldValue): void
+    {
+        static::expectExceptionObject(MigrationException::missingRequestParameter('fieldValue'));
+
+        $request = new Request([], [
+            'entityName' => 'product',
+            'fieldName' => 'name',
+            'fieldValue' => $fieldValue,
+        ]);
+
+        $this->errorResolutionController->validateResolution(
+            $request,
+            Context::createDefaultContext()
+        );
+    }
+
+    public static function invalidResolutionProvider(): \Generator
+    {
+        yield 'null' => ['fieldValue' => null];
+        yield 'empty string' => ['fieldValue' => ''];
+        yield 'empty array' => ['fieldValue' => []];
+    }
+
+    /**
+     * @param array<string, mixed> $expected
+     */
+    #[DataProvider('validateResolutionProvider')]
+    public function testValidateResolution(string $entityName, string $fieldName, mixed $fieldValue, array $expected): void
+    {
+        $request = new Request([], [
+            'entityName' => $entityName,
+            'fieldName' => $fieldName,
+            'fieldValue' => $fieldValue,
+        ]);
+
+        $response = $this->errorResolutionController->validateResolution(
+            $request,
+            Context::createDefaultContext()
+        );
+        $data = $this->jsonResponseToArray($response);
+
+        static::assertArrayHasKey('valid', $data);
+        static::assertArrayHasKey('violations', $data);
+
+        $violationMessages = array_map(static fn (array $violation) => $violation['message'], $data['violations']);
+
+        static::assertSame($expected['valid'], $data['valid']);
+        static::assertSame($expected['violations'], $violationMessages);
+    }
+
+    public static function validateResolutionProvider(): \Generator
+    {
+        yield 'valid product name' => [
+            'entityName' => 'product',
+            'fieldName' => 'name',
+            'fieldValue' => 'Valid Product Name',
+            'expected' => [
+                'valid' => true,
+                'violations' => [],
+            ],
+        ];
+
+        yield 'invalid product stock' => [
+            'entityName' => 'product',
+            'fieldName' => 'stock',
+            'fieldValue' => 'jhdwhawbdh',
+            'expected' => [
+                'valid' => false,
+                'violations' => [
+                    'This value should be of type int.',
+                ],
+            ],
+        ];
+
+        yield 'valid product active' => [
+            'entityName' => 'product',
+            'fieldName' => 'active',
+            'fieldValue' => true,
+            'expected' => [
+                'valid' => true,
+                'violations' => [],
+            ],
+        ];
+
+        yield 'invalid product taxId' => [
+            'entityName' => 'product',
+            'fieldName' => 'taxId',
+            'fieldValue' => 'invalid-uuid',
+            'expected' => [
+                'valid' => false,
+                'violations' => [
+                    'The string "invalid-uuid" is not a valid uuid.',
+                ],
+            ],
+        ];
+
+        yield 'invalid product variant config' => [
+            'entityName' => 'product',
+            'fieldName' => 'variantListingConfig',
+            'fieldValue' => [
+                'displayParent' => 'not-a-boolean',
+                'mainVariantId' => 'also-not-a-uuid',
+                'configuratorGroupConfig' => [],
+            ],
+            'expected' => [
+                'valid' => false,
+                'violations' => [
+                    'This value should be of type boolean.',
+                    'The string "also-not-a-uuid" is not a valid uuid.',
+                ],
+            ],
+        ];
+
+        yield 'valid product price' => [
+            'entityName' => 'product',
+            'fieldName' => 'price',
+            'fieldValue' => [
+                [
+                    'currencyId' => Defaults::CURRENCY,
+                    'gross' => 19.99,
+                    'net' => 16.81,
+                    'linked' => false,
+                ],
+            ],
+            'expected' => [
+                'valid' => true,
+                'violations' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|list<array<string, mixed>>
+     */
+    private function jsonResponseToArray(?Response $response): array
+    {
+        static::assertNotNull($response);
+        static::assertInstanceOf(JsonResponse::class, $response);
+
+        $content = $response->getContent();
+        static::assertIsNotBool($content);
+        static::assertJson($content);
+
+        $array = \json_decode($content, true);
+        static::assertIsArray($array);
+
+        return $array;
+    }
+}

--- a/tests/integration/Migration/Validation/MigrationEntityValidationServiceTest.php
+++ b/tests/integration/Migration/Validation/MigrationEntityValidationServiceTest.php
@@ -34,8 +34,8 @@ use SwagMigrationAssistant\Migration\Validation\Log\MigrationValidationInvalidOp
 use SwagMigrationAssistant\Migration\Validation\Log\MigrationValidationInvalidRequiredFieldValueLog;
 use SwagMigrationAssistant\Migration\Validation\Log\MigrationValidationInvalidRequiredTranslation;
 use SwagMigrationAssistant\Migration\Validation\Log\MigrationValidationMissingRequiredFieldLog;
+use SwagMigrationAssistant\Migration\Validation\MigrationEntityValidationService;
 use SwagMigrationAssistant\Migration\Validation\MigrationValidationResult;
-use SwagMigrationAssistant\Migration\Validation\MigrationValidationService;
 use SwagMigrationAssistant\Profile\Shopware54\Shopware54Profile;
 use SwagMigrationAssistant\Test\Mock\Gateway\Dummy\Local\DummyLocalGateway;
 
@@ -43,8 +43,8 @@ use SwagMigrationAssistant\Test\Mock\Gateway\Dummy\Local\DummyLocalGateway;
  * @internal
  */
 #[Package('fundamentals@after-sales')]
-#[CoversClass(MigrationValidationService::class)]
-class MigrationValidationServiceTest extends TestCase
+#[CoversClass(MigrationEntityValidationService::class)]
+class MigrationEntityValidationServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
@@ -52,7 +52,7 @@ class MigrationValidationServiceTest extends TestCase
 
     private MigrationContext $migrationContext;
 
-    private MigrationValidationService $validationService;
+    private MigrationEntityValidationService $validationService;
 
     /**
      * @var EntityRepository<SwagMigrationLoggingCollection>
@@ -75,7 +75,7 @@ class MigrationValidationServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->validationService = static::getContainer()->get(MigrationValidationService::class);
+        $this->validationService = static::getContainer()->get(MigrationEntityValidationService::class);
         $this->loggingRepo = static::getContainer()->get('swag_migration_logging.repository');
         $this->runRepo = static::getContainer()->get('swag_migration_run.repository');
         $this->mappingRepo = static::getContainer()->get(SwagMigrationMappingDefinition::ENTITY_NAME . '.repository');

--- a/tests/integration/Migration/Validation/MigrationFieldValidationServiceTest.php
+++ b/tests/integration/Migration/Validation/MigrationFieldValidationServiceTest.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SwagMigrationAssistant\Test\integration\Migration\Validation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use SwagMigrationAssistant\Exception\MigrationException;
+use SwagMigrationAssistant\Migration\Validation\MigrationFieldValidationService;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(MigrationFieldValidationService::class)]
+class MigrationFieldValidationServiceTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private MigrationFieldValidationService $migrationFieldValidationService;
+
+    protected function setUp(): void
+    {
+        $this->migrationFieldValidationService = static::getContainer()->get(MigrationFieldValidationService::class);
+    }
+
+    public function testNotExistingEntityDefinition(): void
+    {
+        static::expectExceptionObject(DataAbstractionLayerException::definitionNotFound('test'));
+
+        $this->migrationFieldValidationService->validateFieldValue(
+            'test',
+            'field',
+            'value',
+            Context::createDefaultContext(),
+        );
+    }
+
+    public function testNotExistingField(): void
+    {
+        static::expectExceptionObject(MigrationException::entityFieldNotFound('product', 'nonExistingField'));
+
+        $this->migrationFieldValidationService->validateFieldValue(
+            'product',
+            'nonExistingField',
+            'value',
+            Context::createDefaultContext(),
+        );
+    }
+
+    public function testValidPriceField(): void
+    {
+        static::expectNotToPerformAssertions();
+
+        $this->migrationFieldValidationService->validateFieldValue(
+            'product',
+            'price',
+            [
+                [
+                    'currencyId' => Defaults::CURRENCY,
+                    'gross' => 100.0,
+                    'net' => 84.03,
+                    'linked' => true,
+                ],
+            ],
+            Context::createDefaultContext(),
+        );
+    }
+
+    public function testInvalidPriceFieldGrossType(): void
+    {
+        static::expectException(WriteConstraintViolationException::class);
+
+        $this->migrationFieldValidationService->validateFieldValue(
+            'product',
+            'price',
+            [
+                [
+                    'currencyId' => Defaults::CURRENCY,
+                    'gross' => 'invalid', // should be numeric
+                    'net' => 84.03,
+                    'linked' => true,
+                ],
+            ],
+            Context::createDefaultContext(),
+        );
+    }
+
+    public function testInvalidPriceFieldMissingNet(): void
+    {
+        static::expectException(WriteConstraintViolationException::class);
+
+        $this->migrationFieldValidationService->validateFieldValue(
+            'product',
+            'price',
+            [
+                [
+                    'currencyId' => Defaults::CURRENCY,
+                    'gross' => 100.0,
+                    // 'net' is missing
+                    'linked' => true,
+                ],
+            ],
+            Context::createDefaultContext(),
+        );
+    }
+
+    public function testInvalidPriceFieldCurrencyId(): void
+    {
+        static::expectException(WriteConstraintViolationException::class);
+
+        $this->migrationFieldValidationService->validateFieldValue(
+            'product',
+            'price',
+            [
+                [
+                    'currencyId' => 'not-a-valid-uuid',
+                    'gross' => 100.0,
+                    'net' => 84.03,
+                    'linked' => true,
+                ],
+            ],
+            Context::createDefaultContext(),
+        );
+    }
+}

--- a/tests/integration/Migration/Validation/MigrationFieldValidationServiceTest.php
+++ b/tests/integration/Migration/Validation/MigrationFieldValidationServiceTest.php
@@ -11,11 +11,10 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use SwagMigrationAssistant\Exception\MigrationException;
+use SwagMigrationAssistant\Migration\Validation\Exception\MigrationValidationException;
 use SwagMigrationAssistant\Migration\Validation\MigrationFieldValidationService;
 
 /**
@@ -36,9 +35,9 @@ class MigrationFieldValidationServiceTest extends TestCase
 
     public function testNotExistingEntityDefinition(): void
     {
-        static::expectExceptionObject(DataAbstractionLayerException::definitionNotFound('test'));
+        static::expectExceptionObject(MigrationException::entityNotExists('test', 'field'));
 
-        $this->migrationFieldValidationService->validateFieldValue(
+        $this->migrationFieldValidationService->validateField(
             'test',
             'field',
             'value',
@@ -48,9 +47,9 @@ class MigrationFieldValidationServiceTest extends TestCase
 
     public function testNotExistingField(): void
     {
-        static::expectExceptionObject(MigrationException::entityFieldNotFound('product', 'nonExistingField'));
+        static::expectExceptionObject(MigrationValidationException::entityFieldNotFound('product', 'nonExistingField'));
 
-        $this->migrationFieldValidationService->validateFieldValue(
+        $this->migrationFieldValidationService->validateField(
             'product',
             'nonExistingField',
             'value',
@@ -62,7 +61,7 @@ class MigrationFieldValidationServiceTest extends TestCase
     {
         static::expectNotToPerformAssertions();
 
-        $this->migrationFieldValidationService->validateFieldValue(
+        $this->migrationFieldValidationService->validateField(
             'product',
             'price',
             [
@@ -79,9 +78,9 @@ class MigrationFieldValidationServiceTest extends TestCase
 
     public function testInvalidPriceFieldGrossType(): void
     {
-        static::expectException(WriteConstraintViolationException::class);
+        static::expectException(MigrationValidationException::class);
 
-        $this->migrationFieldValidationService->validateFieldValue(
+        $this->migrationFieldValidationService->validateField(
             'product',
             'price',
             [
@@ -98,9 +97,9 @@ class MigrationFieldValidationServiceTest extends TestCase
 
     public function testInvalidPriceFieldMissingNet(): void
     {
-        static::expectException(WriteConstraintViolationException::class);
+        static::expectException(MigrationValidationException::class);
 
-        $this->migrationFieldValidationService->validateFieldValue(
+        $this->migrationFieldValidationService->validateField(
             'product',
             'price',
             [
@@ -117,9 +116,9 @@ class MigrationFieldValidationServiceTest extends TestCase
 
     public function testInvalidPriceFieldCurrencyId(): void
     {
-        static::expectException(WriteConstraintViolationException::class);
+        static::expectException(MigrationValidationException::class);
 
-        $this->migrationFieldValidationService->validateFieldValue(
+        $this->migrationFieldValidationService->validateField(
             'product',
             'price',
             [

--- a/tests/unit/Migration/ErrorResolution/MigrationFieldExampleGeneratorTest.php
+++ b/tests/unit/Migration/ErrorResolution/MigrationFieldExampleGeneratorTest.php
@@ -81,12 +81,12 @@ class MigrationFieldExampleGeneratorTest extends TestCase
 
         yield 'DateField' => [
             'field' => new DateField('test', 'test'),
-            'expected' => '"[date]"',
+            'expected' => '"[date (Y-m-d)]"',
         ];
 
         yield 'DateTimeField' => [
             'field' => new DateTimeField('test', 'test'),
-            'expected' => '"[datetime]"',
+            'expected' => '"[datetime (Y-m-d H:i:s.v)]"',
         ];
 
         yield 'CustomFields' => [

--- a/tests/unit/Migration/ErrorResolution/MigrationFieldExampleGeneratorTest.php
+++ b/tests/unit/Migration/ErrorResolution/MigrationFieldExampleGeneratorTest.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SwagMigrationAssistant\Test\unit\Migration\ErrorResolution;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CalculatedPriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CartPriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CashRoundingConfigField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ObjectField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceDefinitionField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TaxFreeConfigField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\VariantListingConfigField;
+use Shopware\Core\Framework\Log\Package;
+use SwagMigrationAssistant\Migration\ErrorResolution\MigrationFieldExampleGenerator;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(MigrationFieldExampleGenerator::class)]
+class MigrationFieldExampleGeneratorTest extends TestCase
+{
+    public function testGetFieldType(): void
+    {
+        static::assertSame(MigrationFieldExampleGenerator::getFieldType(new StringField('test', 'test')), 'StringField');
+        static::assertSame(MigrationFieldExampleGenerator::getFieldType(new IntField('test', 'test')), 'IntField');
+    }
+
+    #[DataProvider('exampleFieldProvider')]
+    public function testGenerateExample(Field $field, ?string $expected): void
+    {
+        $example = MigrationFieldExampleGenerator::generateExample($field);
+        static::assertSame($expected, $example);
+    }
+
+    public static function exampleFieldProvider(): \Generator
+    {
+        yield 'IntField' => [
+            'field' => new IntField('test', 'test'),
+            'expected' => '0',
+        ];
+
+        yield 'FloatField' => [
+            'field' => new FloatField('test', 'test'),
+            'expected' => '0.1',
+        ];
+
+        yield 'StringField' => [
+            'field' => new StringField('test', 'test'),
+            'expected' => '"[string]"',
+        ];
+
+        yield 'IdField' => [
+            'field' => new IdField('test', 'test'),
+            'expected' => '"[uuid]"',
+        ];
+
+        yield 'FkField' => [
+            'field' => new FkField('test', 'test', 'test'),
+            'expected' => '"[uuid]"',
+        ];
+
+        yield 'DateField' => [
+            'field' => new DateField('test', 'test'),
+            'expected' => '"[date]"',
+        ];
+
+        yield 'DateTimeField' => [
+            'field' => new DateTimeField('test', 'test'),
+            'expected' => '"[datetime]"',
+        ];
+
+        yield 'CustomFields' => [
+            'field' => new CustomFields('test', 'test'),
+            'expected' => null,
+        ];
+
+        yield 'ObjectField' => [
+            'field' => new ObjectField('test', 'test'),
+            'expected' => null,
+        ];
+
+        yield 'JsonField without property mapping' => [
+            'field' => new JsonField('test', 'test'),
+            'expected' => '[]',
+        ];
+
+        yield 'JsonField with property mapping' => [
+            'field' => new JsonField('test', 'test', [new StringField('innerString', 'innerString')]),
+            'expected' => \json_encode(['innerString' => '[string]'], \JSON_PRETTY_PRINT),
+        ];
+
+        yield 'ListField without field type' => [
+            'field' => new ListField('test', 'test'),
+            'expected' => '[]',
+        ];
+
+        yield 'ListField with field type' => [
+            'field' => new ListField('test', 'test', StringField::class),
+            'expected' => \json_encode(['[string]'], \JSON_PRETTY_PRINT),
+        ];
+    }
+
+    #[DataProvider('specialFieldProvider')]
+    public function testGenerateExampleSpecialFields(Field $field): void
+    {
+        $example = MigrationFieldExampleGenerator::generateExample($field);
+
+        // not null means the special field was handled
+        static::assertNotNull($example);
+    }
+
+    public static function specialFieldProvider(): \Generator
+    {
+        yield 'CalculatedPriceField' => [
+            'field' => new CalculatedPriceField('test', 'test'),
+        ];
+
+        yield 'CartPriceField' => [
+            'field' => new CartPriceField('test', 'test'),
+        ];
+
+        yield 'PriceDefinitionField' => [
+            'field' => new PriceDefinitionField('test', 'test'),
+        ];
+
+        yield 'PriceField' => [
+            'field' => new PriceField('test', 'test'),
+        ];
+
+        yield 'VariantListingConfigField' => [
+            'field' => new VariantListingConfigField('test', 'test'),
+        ];
+
+        yield 'CashRoundingConfigField' => [
+            'field' => new CashRoundingConfigField('test', 'test'),
+        ];
+
+        yield 'TaxFreeConfigField' => [
+            'field' => new TaxFreeConfigField('test', 'test'),
+        ];
+    }
+}

--- a/tests/unit/Migration/ErrorResolution/MigrationFieldExampleGeneratorTest.php
+++ b/tests/unit/Migration/ErrorResolution/MigrationFieldExampleGeneratorTest.php
@@ -28,6 +28,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceDefinitionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TaxFreeConfigField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VariantListingConfigField;
 use Shopware\Core\Framework\Log\Package;
 use SwagMigrationAssistant\Migration\ErrorResolution\MigrationFieldExampleGenerator;
@@ -66,6 +67,11 @@ class MigrationFieldExampleGeneratorTest extends TestCase
 
         yield 'StringField' => [
             'field' => new StringField('test', 'test'),
+            'expected' => '"[string]"',
+        ];
+
+        yield 'TranslatedField' => [
+            'field' => new TranslatedField('test'),
             'expected' => '"[string]"',
         ];
 


### PR DESCRIPTION
Apply the same validation strategy we use to flag bad field values during error resolution to the values the user propose as fixes. Also for JSON inputs like cart prices, show users concrete example values they can adapt.