### PR TITLE
fix: ESM compatibility in jest config

### DIFF
--- a/tests/Jest/jest.config.js
+++ b/tests/Jest/jest.config.js
@@ -74,7 +74,7 @@ module.exports = {
     },
 
     transformIgnorePatterns: [
-        '/node_modules/(?!(uuidv7|other)/)',
+        '/node_modules/(?!(@shopware-ag/meteor-component-library|@shopware-ag/meteor-icon-kit|uuidv7|other)/)',
     ],
 
     // testEnvironment: 'jsdom',

--- a/tests/Jest/jest.config.js
+++ b/tests/Jest/jest.config.js
@@ -69,6 +69,8 @@ module.exports = {
         '^\@shopware-ag\/meteor-component-library$': `${resolve(join(process.env.ADMIN_PATH, '/node_modules'))}/@shopware-ag/meteor-component-library/dist/common/index.js`,
         '^@administration(.*)$': `${process.env.ADMIN_PATH}/src$1`,
         '^SwagMigrationAssistant/(.*)$': '<rootDir>/src/Resources/app/administration/src/$1',
+        '^lodash-es$': 'lodash',
+        '^lodash-es/(.*)$': 'lodash/$1',
     },
 
     transformIgnorePatterns: [


### PR DESCRIPTION
broken on `trunk`, see https://github.com/shopware/SwagMigrationAssistant/actions/runs/21249279766/job/61146341269

since this was caused by a change in platform IIRC, should we always run jest on PRs to avoid issues like this?

https://github.com/shopware/SwagMigrationAssistant/blob/7954f78a465ddba0ef428b3d3284f15eddbb1286/.github/workflows/admin.yaml#L8-L12