### PR TITLE
fix: use stable ID for `main_category` mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 16.0.0
 
+- #14517 - Fixed duplicate key error when re-migrating products with SEO main categories after checksum reset
 - #14400 - Removed the "Delete migration data" action from the migration history context menu
 - #13898 - Fixed migration of orders with different tax rates on line items from SW5
 - #11808 - Introduced Error Resolution to manage data inconsistencies and apply migration fixes directly in the SW6 administration, instead of fixing issues in the source system as it was needed previously.

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,6 @@
 # 16.0.0
 
+- #14517 - Fehler bei doppeltem Schlüssel beim erneuten Migrieren von Produkten mit SEO-Hauptkategorien nach dem Zurücksetzen der Prüfsummen behoben
 - #14400 - Die Aktion „Migrationsdaten löschen" wurde aus dem Kontextmenü der Migrationshistorie entfernt
 - #13898 - Migration von Bestellungen mit unterschiedlichen Steuersätzen auf Positionen aus SW5 behoben
 - #11808 - Einführung einer Benutzeroberfläche zur Fehlerbehebung, um Dateninkonsistenzen zu beheben und Migrationskorrekturen direkt in der SW6 Administration vorzunehmen, anstatt wie zuvor im Quellsystem.

--- a/src/Migration/DataSelection/DefaultEntities.php
+++ b/src/Migration/DataSelection/DefaultEntities.php
@@ -183,6 +183,8 @@ final class DefaultEntities
 
     final public const PRODUCT_VISIBILITY = 'product_visibility';
 
+    final public const PRODUCT_MAIN_CATEGORY = 'product_main_category';
+
     final public const PROMOTION = 'promotion';
 
     final public const PROMOTION_DISCOUNT = 'promotion_discount';

--- a/src/Profile/Shopware/Converter/ProductConverter.php
+++ b/src/Profile/Shopware/Converter/ProductConverter.php
@@ -1497,6 +1497,13 @@ abstract class ProductConverter extends ShopwareConverter
     {
         $mainCategories = [];
         foreach ($categories as $category) {
+            $id = $this->mappingService->getOrCreateMapping(
+                $this->connectionId,
+                DefaultEntities::PRODUCT_MAIN_CATEGORY,
+                $category['id'],
+                $this->context
+            )['entityId'];
+
             $categoryId = $this->mappingService->getOrCreateMapping(
                 $this->connectionId,
                 DefaultEntities::CATEGORY,
@@ -1516,6 +1523,7 @@ abstract class ProductConverter extends ShopwareConverter
             }
 
             $mainCategories[] = [
+                'id' => $id,
                 'categoryId' => $categoryId,
                 'salesChannelId' => $salesChannelId,
             ];

--- a/src/Profile/Shopware/Converter/ProductConverter.php
+++ b/src/Profile/Shopware/Converter/ProductConverter.php
@@ -1518,7 +1518,7 @@ abstract class ProductConverter extends ShopwareConverter
                 $this->context
             )['entityId'];
 
-            if (!$categoryId || !$salesChannelId) {
+            if (!$id || !$categoryId || !$salesChannelId) {
                 continue;
             }
 

--- a/src/Profile/Shopware/Gateway/Local/Reader/ProductReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/ProductReader.php
@@ -195,7 +195,7 @@ class ProductReader extends AbstractReader implements ReaderInterface
         // Just select subshop main categories and ignore language shops
         $connection = $this->getConnection($migrationContext);
         $query = $connection->createQueryBuilder();
-        $query->select('seoCategory.article_id', 'seoCategory.shop_id as shopId', 'seoCategory.category_id as categoryId')
+        $query->select('seoCategory.article_id', 'seoCategory.id', 'seoCategory.shop_id as shopId', 'seoCategory.category_id as categoryId')
             ->from('s_articles_categories_seo', 'seoCategory')
             ->join('seoCategory', 's_core_shops', 'shop', 'shop.id = seoCategory.shop_id')
             ->where('article_id IN (:ids)')

--- a/tests/Profile/Shopware/Gateway/Local/ProductReaderTest.php
+++ b/tests/Profile/Shopware/Gateway/Local/ProductReaderTest.php
@@ -136,15 +136,19 @@ class ProductReaderTest extends LocalConnectionTestCase
 
         $productOne = $this->getProductById(9, $data);
         static::assertCount(2, $productOne['mainCategories']);
+        static::assertSame('6', $productOne['mainCategories'][0]['id']);
         static::assertSame('1', $productOne['mainCategories'][0]['shopId']);
         static::assertSame('14', $productOne['mainCategories'][0]['categoryId']);
+        static::assertSame('8', $productOne['mainCategories'][1]['id']);
         static::assertSame('3', $productOne['mainCategories'][1]['shopId']);
         static::assertSame('34', $productOne['mainCategories'][1]['categoryId']);
 
         $productTwo = $this->getProductById(272, $data);
         static::assertCount(2, $productTwo['mainCategories']);
+        static::assertSame('3', $productTwo['mainCategories'][0]['id']);
         static::assertSame('1', $productTwo['mainCategories'][0]['shopId']);
         static::assertSame('15', $productTwo['mainCategories'][0]['categoryId']);
+        static::assertSame('5', $productTwo['mainCategories'][1]['id']);
         static::assertSame('3', $productTwo['mainCategories'][1]['shopId']);
         static::assertSame('16', $productTwo['mainCategories'][1]['categoryId']);
     }

--- a/tests/Profile/Shopware54/Converter/ProductConverterTest.php
+++ b/tests/Profile/Shopware54/Converter/ProductConverterTest.php
@@ -82,9 +82,11 @@ class ProductConverterTest extends TestCase
         $result = $convertedResult['mainCategories'];
 
         foreach ($result as $mainSeoCategory) {
+            static::assertArrayHasKey('id', $mainSeoCategory);
             static::assertArrayHasKey('categoryId', $mainSeoCategory);
             static::assertArrayHasKey('salesChannelId', $mainSeoCategory);
 
+            static::assertTrue(Uuid::isValid($mainSeoCategory['id']));
             static::assertTrue(Uuid::isValid($mainSeoCategory['categoryId']));
             static::assertTrue(Uuid::isValid($mainSeoCategory['salesChannelId']));
         }

--- a/tests/Profile/Shopware54/Converter/_fixtures/product_with_seo_main_category.php
+++ b/tests/Profile/Shopware54/Converter/_fixtures/product_with_seo_main_category.php
@@ -199,10 +199,12 @@ return [
         ],
         'mainCategories' => [
             [
+                'id' => '1',
                 'shopId' => '1',
                 'categoryId' => '15',
             ],
             [
+                'id' => '2',
                 'shopId' => '3',
                 'categoryId' => '51',
             ],


### PR DESCRIPTION
resolves shopware/shopware#14517

Adds stable ID mapping for `main_category` entities by using the source `s_articles_categories_seo.id` instead of generating random UUIDs, preventing duplicate key violations on re-migration after checksum reset. 

requires shopware/SwagMigrationConnector#7