### PR TITLE
fix: selected counter in select all mode

### DIFF
--- a/src/Resources/app/administration/src/module/swag-migration/component/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/index.ts
@@ -8,6 +8,7 @@ import './swag-migration-error-resolution';
 
 Shopware.Component.register('swag-migration-dashboard-card', () => import('./swag-migration-dashboard-card'));
 Shopware.Component.extend('swag-migration-grid-extended', 'sw-grid', () => import('./swag-migration-grid-extended'));
+Shopware.Component.extend('swag-migration-data-grid-extended', 'sw-data-grid', () => import('./swag-migration-data-grid-extended'));
 Shopware.Component.register('swag-migration-grid-selection', () => import('./swag-migration-grid-selection'));
 Shopware.Component.register('swag-migration-settings-icon', () => import('./swag-migration-settings-icon'));
 Shopware.Component.register('swag-migration-tab-card', () => import('./swag-migration-tab-card'));

--- a/src/Resources/app/administration/src/module/swag-migration/component/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/index.ts
@@ -8,7 +8,11 @@ import './swag-migration-error-resolution';
 
 Shopware.Component.register('swag-migration-dashboard-card', () => import('./swag-migration-dashboard-card'));
 Shopware.Component.extend('swag-migration-grid-extended', 'sw-grid', () => import('./swag-migration-grid-extended'));
-Shopware.Component.extend('swag-migration-data-grid-extended', 'sw-data-grid', () => import('./swag-migration-data-grid-extended'));
+Shopware.Component.extend(
+    'swag-migration-data-grid-extended',
+    'sw-data-grid',
+    () => import('./swag-migration-data-grid-extended'),
+);
 Shopware.Component.register('swag-migration-grid-selection', () => import('./swag-migration-grid-selection'));
 Shopware.Component.register('swag-migration-settings-icon', () => import('./swag-migration-settings-icon'));
 Shopware.Component.register('swag-migration-tab-card', () => import('./swag-migration-tab-card'));

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-data-grid-extended/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-data-grid-extended/index.ts
@@ -23,9 +23,7 @@ export default Shopware.Component.wrapComponentConfig({
                 return this.lastSelectionCount;
             }
 
-            return this.customSelectionCount !== null
-                ? this.customSelectionCount
-                : Object.values(this.selection).length;
+            return this.customSelectionCount !== null ? this.customSelectionCount : Object.values(this.selection).length;
         },
     },
 

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-data-grid-extended/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-data-grid-extended/index.ts
@@ -1,0 +1,42 @@
+/**
+ * @private
+ * @sw-package fundamentals@after-sales
+ */
+export default Shopware.Component.wrapComponentConfig({
+    props: {
+        customSelectionCount: {
+            type: Number,
+            required: false,
+            default: null,
+        },
+    },
+
+    data() {
+        return {
+            lastSelectionCount: 0,
+        };
+    },
+
+    computed: {
+        selectionCount(): number {
+            if (this.isLoading && this.lastSelectionCount > 0) {
+                return this.lastSelectionCount;
+            }
+
+            return this.customSelectionCount !== null
+                ? this.customSelectionCount
+                : Object.values(this.selection).length;
+        },
+    },
+
+    watch: {
+        customSelectionCount: {
+            handler(newVal: number | null) {
+                if (!this.isLoading && newVal !== null && newVal > 0) {
+                    this.lastSelectionCount = newVal;
+                }
+            },
+            immediate: true,
+        },
+    },
+});

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
@@ -191,7 +191,7 @@ export default Shopware.Component.wrapComponentConfig({
             if (this.selectAllMode) {
                 return this.tableTotal;
             }
-            
+
             return this.selectedLogIds.length;
         },
     },

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
@@ -186,6 +186,14 @@ export default Shopware.Component.wrapComponentConfig({
         isResolutionDisabled(): boolean {
             return this.loading || (this.selectedLogIds.length === 0 && !this.selectAllMode);
         },
+
+        selectedCount(): number {
+            if (this.selectAllMode) {
+                return this.tableTotal;
+            }
+            
+            return this.selectedLogIds.length;
+        },
     },
 
     methods: {

--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/swag-migration-error-resolution-modal.html.twig
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/swag-migration-error-resolution-modal.html.twig
@@ -14,7 +14,7 @@
         <div class="swag-migration-error-resolution-modal__container">
             {% block swag_migration_error_resolution_modal_left %}
                 <div class="swag-migration-error-resolution-modal__left">
-                    <sw-data-grid
+                    <swag-migration-data-grid-extended
                         class="swag-migration-error-resolution-modal__left-grid"
                         ref="errorResolutionGrid"
                         :identifier="tableIdentifier"
@@ -28,6 +28,7 @@
                         :skeleton-item-amount="tableLimit"
                         :pre-selection="preSelection"
                         :is-record-selectable="isRecordSelectable"
+                        :custom-selection-count="selectedCount"
                         @selection-change="onSelectionChanged"
                     >
                         <template #column-status="{ item }">
@@ -83,7 +84,7 @@
                                 @page-change="onPageChange"
                             />
                         </template>
-                    </sw-data-grid>
+                    </swag-migration-data-grid-extended>
                 </div>
             {% endblock %}
 
@@ -91,7 +92,7 @@
                 <div class="swag-migration-error-resolution-modal__right">
                     <div class="swag-migration-error-resolution-modal__right-header">
                         <h2 class="swag-migration-error-resolution-modal__right-header-title">
-                            {{ $tc('swag-migration.index.error-resolution.modals.error.right.title', { count: selectedLogIds?.length }) }}
+                            {{ $tc('swag-migration.index.error-resolution.modals.error.right.title', { count: selectedCount }) }}
                         </h2>
                     </div>
 

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-data-grid-extended.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-data-grid-extended.spec.js
@@ -17,7 +17,7 @@ const defaultProps = {
 
 async function createWrapper(props = {}) {
     await wrapTestComponent('sw-data-grid');
-    
+
     Shopware.Component.extend('swag-migration-data-grid-extended', 'sw-data-grid', SwagMigrationDataGridExtended);
 
     return mount(await Shopware.Component.build('swag-migration-data-grid-extended'), {

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-data-grid-extended.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-data-grid-extended.spec.js
@@ -1,0 +1,124 @@
+/**
+ * @sw-package after-sales
+ */
+import { mount } from '@vue/test-utils';
+import SwagMigrationDataGridExtended from 'SwagMigrationAssistant/module/swag-migration/component/swag-migration-data-grid-extended';
+
+const defaultProps = {
+    columns: [
+        { property: 'name', label: 'Name' },
+    ],
+    dataSource: [
+        { id: '1', name: 'Item 1' },
+        { id: '2', name: 'Item 2' },
+    ],
+    showSelection: true,
+};
+
+async function createWrapper(props = {}) {
+    await wrapTestComponent('sw-data-grid');
+    
+    Shopware.Component.extend('swag-migration-data-grid-extended', 'sw-data-grid', SwagMigrationDataGridExtended);
+
+    return mount(await Shopware.Component.build('swag-migration-data-grid-extended'), {
+        props: {
+            ...defaultProps,
+            ...props,
+        },
+        global: {
+            stubs: {
+                'sw-context-menu-item': true,
+                'sw-context-button': true,
+                'sw-context-menu': true,
+                'sw-data-grid-column-boolean': true,
+                'sw-data-grid-inline-edit': true,
+                'sw-data-grid-settings': true,
+                'sw-data-grid-skeleton': true,
+                'sw-checkbox-field': true,
+                'sw-popover': true,
+                'sw-provide': true,
+                'router-link': true,
+                'sw-icon': true,
+            },
+        },
+    });
+}
+
+describe('module/swag-migration/component/swag-migration-data-grid-extended', () => {
+    describe('selectionCount', () => {
+        it('should use customSelectionCount when provided', async () => {
+            const wrapper = await createWrapper({
+                customSelectionCount: 100,
+            });
+
+            expect(wrapper.vm.selectionCount).toBe(100);
+        });
+
+        it('should fall back to selection length when customSelectionCount is null', async () => {
+            const wrapper = await createWrapper({
+                customSelectionCount: null,
+            });
+
+            expect(wrapper.vm.selectionCount).toBe(0);
+
+            wrapper.vm.selection = { item1: {}, item2: {} };
+            await wrapper.vm.$nextTick();
+
+            expect(wrapper.vm.selectionCount).toBe(2);
+        });
+
+        it('should preserve previous count during loading', async () => {
+            const wrapper = await createWrapper({
+                customSelectionCount: 50,
+                isLoading: false,
+            });
+
+            expect(wrapper.vm.selectionCount).toBe(50);
+
+            await wrapper.setProps({
+                isLoading: true,
+                customSelectionCount: 0,
+            });
+
+            expect(wrapper.vm.selectionCount).toBe(50);
+        });
+
+        it('should update count after loading completes', async () => {
+            const wrapper = await createWrapper({
+                customSelectionCount: 50,
+                isLoading: false,
+            });
+
+            expect(wrapper.vm.selectionCount).toBe(50);
+
+            await wrapper.setProps({
+                isLoading: true,
+                customSelectionCount: 0,
+            });
+
+            expect(wrapper.vm.selectionCount).toBe(50);
+
+            await wrapper.setProps({
+                isLoading: false,
+                customSelectionCount: 75,
+            });
+
+            expect(wrapper.vm.selectionCount).toBe(75);
+        });
+
+        it('should not preserve count if previous count was zero', async () => {
+            const wrapper = await createWrapper({
+                customSelectionCount: 0,
+                isLoading: false,
+            });
+
+            expect(wrapper.vm.selectionCount).toBe(0);
+
+            await wrapper.setProps({
+                isLoading: true,
+            });
+
+            expect(wrapper.vm.selectionCount).toBe(0);
+        });
+    });
+});

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
@@ -144,9 +144,7 @@ async function createWrapper(props = defaultProps) {
                 'swag-migration-error-resolution-field': await Shopware.Component.build(
                     'swag-migration-error-resolution-field',
                 ),
-                'swag-migration-data-grid-extended': await Shopware.Component.build(
-                    'swag-migration-data-grid-extended',
-                ),
+                'swag-migration-data-grid-extended': await Shopware.Component.build('swag-migration-data-grid-extended'),
                 'sw-entity-single-select': await wrapTestComponent('sw-entity-single-select'),
                 'sw-select-result-list': await wrapTestComponent('sw-select-result-list'),
                 'sw-popover-deprecated': await wrapTestComponent('sw-popover-deprecated'),
@@ -218,7 +216,11 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
             await flushPromises();
 
             wrapper.vm.selectAllMode = false;
-            wrapper.vm.selectedLogIds = ['log-1', 'log-2', 'log-3'];
+            wrapper.vm.selectedLogIds = [
+                'log-1',
+                'log-2',
+                'log-3',
+            ];
 
             expect(wrapper.vm.selectedCount).toBe(3);
         });
@@ -237,9 +239,9 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
             await flushPromises();
 
             expect(wrapper.vm.loading).toBe(false);
-            expect(
-                wrapper.findComponent('.swag-migration-error-resolution-modal__left-grid').props('isLoading'),
-            ).toBe(false);
+            expect(wrapper.findComponent('.swag-migration-error-resolution-modal__left-grid').props('isLoading')).toBe(
+                false,
+            );
 
             expect(migrationLoggingRepositoryMock.search).toHaveBeenNthCalledWith(
                 1,

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
@@ -201,28 +201,41 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
     });
 
     describe('selectedCount', () => {
-        it('should return tableTotal when selectAllMode is active', async () => {
+        it('should display tableTotal when selectAllMode is active', async () => {
+            migrationFixRepositoryMock.search.mockReturnValueOnce(Promise.resolve([]));
+
             const wrapper = await createWrapper();
             await flushPromises();
 
-            wrapper.vm.selectAllMode = true;
-            wrapper.vm.tableTotal = 150;
+            const rowCheckboxes = wrapper.findAll('.sw-data-grid__body .mt-field--checkbox input');
+            await rowCheckboxes[0].setChecked(true);
+            await flushPromises();
 
-            expect(wrapper.vm.selectedCount).toBe(150);
+            const selectAllButton = wrapper.find('.sw-data-grid__bulk .bulk-link button');
+            await selectAllButton.trigger('click');
+            await flushPromises();
+
+            const row0Checkbox = wrapper.find('.sw-data-grid__row--0 .mt-field--checkbox input');
+            const row1Checkbox = wrapper.find('.sw-data-grid__row--1 .mt-field--checkbox input');
+
+            expect(row0Checkbox.attributes('disabled')).toBeDefined();
+            expect(row1Checkbox.attributes('disabled')).toBeDefined();
+            expect(wrapper.find('.sw-data-grid__bulk-selected-count').text()).toBe('2');
         });
 
-        it('should return selectedLogIds length when selectAllMode is inactive', async () => {
+        it('should display selectedLogIds length when selectAllMode is inactive', async () => {
+            migrationFixRepositoryMock.search.mockReturnValueOnce(Promise.resolve([]));
+
             const wrapper = await createWrapper();
             await flushPromises();
 
-            wrapper.vm.selectAllMode = false;
-            wrapper.vm.selectedLogIds = [
-                'log-1',
-                'log-2',
-                'log-3',
-            ];
+            expect(wrapper.find('.sw-data-grid__bulk-selected-count').exists()).toBe(false);
 
-            expect(wrapper.vm.selectedCount).toBe(3);
+            const rowCheckboxes = wrapper.findAll('.sw-data-grid__body .mt-field--checkbox input');
+            await rowCheckboxes[0].setChecked(true);
+            await flushPromises();
+
+            expect(wrapper.find('.sw-data-grid__bulk-selected-count').text()).toBe('1');
         });
     });
 

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
@@ -201,28 +201,6 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
     });
 
     describe('selectedCount', () => {
-        it('should display tableTotal when selectAllMode is active', async () => {
-            migrationFixRepositoryMock.search.mockReturnValueOnce(Promise.resolve([]));
-
-            const wrapper = await createWrapper();
-            await flushPromises();
-
-            const rowCheckboxes = wrapper.findAll('.sw-data-grid__body .mt-field--checkbox input');
-            await rowCheckboxes[0].setChecked(true);
-            await flushPromises();
-
-            const selectAllButton = wrapper.find('.sw-data-grid__bulk .bulk-link button');
-            await selectAllButton.trigger('click');
-            await flushPromises();
-
-            const row0Checkbox = wrapper.find('.sw-data-grid__row--0 .mt-field--checkbox input');
-            const row1Checkbox = wrapper.find('.sw-data-grid__row--1 .mt-field--checkbox input');
-
-            expect(row0Checkbox.attributes('disabled')).toBeDefined();
-            expect(row1Checkbox.attributes('disabled')).toBeDefined();
-            expect(wrapper.find('.sw-data-grid__bulk-selected-count').text()).toBe('2');
-        });
-
         it('should display selectedLogIds length when selectAllMode is inactive', async () => {
             migrationFixRepositoryMock.search.mockReturnValueOnce(Promise.resolve([]));
 
@@ -236,6 +214,52 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
             await flushPromises();
 
             expect(wrapper.find('.sw-data-grid__bulk-selected-count').text()).toBe('1');
+        });
+
+        it('should display tableTotal in selectAllMode and persist across page navigation', async () => {
+            const defaultLoggingSearch = migrationLoggingRepositoryMock.search.getMockImplementation();
+            const defaultFixSearch = migrationFixRepositoryMock.search.getMockImplementation();
+
+            const paginatedLogs = Array.from({ length: 28 }, (_, i) => ({
+                ...logMocks[0],
+                id: `log-id-${i + 1}`,
+                entityId: `log-entity-id-${i + 1}`,
+            }));
+
+            migrationLoggingRepositoryMock.search.mockImplementation((criteria) => {
+                const page = criteria.page;
+                const limit = criteria.limit;
+                const start = (page - 1) * limit;
+                const end = start + limit;
+
+                const result = paginatedLogs.slice(start, end);
+                result.total = paginatedLogs.length;
+
+                return Promise.resolve(result);
+            });
+            migrationFixRepositoryMock.search.mockImplementation(() => Promise.resolve([]));
+
+            const wrapper = await createWrapper();
+            await flushPromises();
+
+            const rowCheckboxes = wrapper.findAll('.sw-data-grid__body .mt-field--checkbox input');
+            await rowCheckboxes[0].setChecked(true);
+            await flushPromises();
+
+            const selectAllButton = wrapper.find('.sw-data-grid__bulk .bulk-link button');
+            await selectAllButton.trigger('click');
+            await flushPromises();
+
+            expect(wrapper.find('.sw-data-grid__row--0 .mt-field--checkbox input').attributes('disabled')).toBeDefined();
+            expect(wrapper.find('.sw-data-grid__bulk-selected-count').text()).toBe('28');
+
+            await wrapper.find('.sw-pagination__page-button-next').trigger('click');
+            await flushPromises();
+
+            expect(wrapper.find('.sw-data-grid__bulk-selected-count').text()).toBe('28');
+
+            migrationLoggingRepositoryMock.search.mockImplementation(defaultLoggingSearch);
+            migrationFixRepositoryMock.search.mockImplementation(defaultFixSearch);
         });
     });
 

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
@@ -10,6 +10,7 @@ import SwagMigrationErrorResolutionField from 'SwagMigrationAssistant/module/swa
 import SwagMigrationErrorResolutionFieldScalar from 'SwagMigrationAssistant/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-scalar';
 import SwagMigrationErrorResolutionFieldRelation from 'SwagMigrationAssistant/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-field/swag-migration-error-resolution-field-relation';
 import SwagMigrationErrorResolutionService from 'SwagMigrationAssistant/module/swag-migration/service/swag-migration-error-resolution.service';
+import SwagMigrationDataGridExtended from 'SwagMigrationAssistant/module/swag-migration/component/swag-migration-data-grid-extended';
 import { fixtureLogGroups, fixtureLogs, fixtureFixes } from '@/fixture';
 
 const { EntityCollection } = Shopware.Data;
@@ -124,6 +125,9 @@ const repositoryFactoryMock = {
 };
 
 async function createWrapper(props = defaultProps) {
+    await wrapTestComponent('sw-data-grid');
+    Shopware.Component.extend('swag-migration-data-grid-extended', 'sw-data-grid', SwagMigrationDataGridExtended);
+
     return mount(await Shopware.Component.build('swag-migration-error-resolution-modal'), {
         props,
         global: {
@@ -139,6 +143,9 @@ async function createWrapper(props = defaultProps) {
                 ),
                 'swag-migration-error-resolution-field': await Shopware.Component.build(
                     'swag-migration-error-resolution-field',
+                ),
+                'swag-migration-data-grid-extended': await Shopware.Component.build(
+                    'swag-migration-data-grid-extended',
                 ),
                 'sw-entity-single-select': await wrapTestComponent('sw-entity-single-select'),
                 'sw-select-result-list': await wrapTestComponent('sw-select-result-list'),
@@ -195,12 +202,34 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
         });
     });
 
+    describe('selectedCount', () => {
+        it('should return tableTotal when selectAllMode is active', async () => {
+            const wrapper = await createWrapper();
+            await flushPromises();
+
+            wrapper.vm.selectAllMode = true;
+            wrapper.vm.tableTotal = 150;
+
+            expect(wrapper.vm.selectedCount).toBe(150);
+        });
+
+        it('should return selectedLogIds length when selectAllMode is inactive', async () => {
+            const wrapper = await createWrapper();
+            await flushPromises();
+
+            wrapper.vm.selectAllMode = false;
+            wrapper.vm.selectedLogIds = ['log-1', 'log-2', 'log-3'];
+
+            expect(wrapper.vm.selectedCount).toBe(3);
+        });
+    });
+
     describe('initial loading', () => {
         it('should load initial data when modal is opened', async () => {
             const wrapper = await createWrapper();
 
             expect(wrapper.vm.loading).toBe(true);
-            expect(wrapper.find('.swag-migration-error-resolution-modal__left-grid').attributes('is-loading')).toBe('true');
+            expect(wrapper.findComponent('.swag-migration-error-resolution-modal__left-grid').props('isLoading')).toBe(true);
             expect(
                 wrapper.find('.swag-migration-error-resolution-modal__right-content-button').attributes('disabled'),
             ).toBeDefined();
@@ -209,8 +238,8 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
 
             expect(wrapper.vm.loading).toBe(false);
             expect(
-                wrapper.find('.swag-migration-error-resolution-modal__left-grid').attributes('is-loading'),
-            ).toBeUndefined();
+                wrapper.findComponent('.swag-migration-error-resolution-modal__left-grid').props('isLoading'),
+            ).toBe(false);
 
             expect(migrationLoggingRepositoryMock.search).toHaveBeenNthCalledWith(
                 1,

--- a/tests/Jest/src/module/swag-migration/index.spec.js
+++ b/tests/Jest/src/module/swag-migration/index.spec.js
@@ -143,6 +143,7 @@ describe('src/module/swag-migration/index', () => {
         ];
 
         const componentsExtended = [
+            'swag-migration-data-grid-extended',
             'swag-migration-grid-extended',
             'swag-migration-index',
             'swag-migration-process-screen',


### PR DESCRIPTION
resolves https://github.com/shopware/shopware/issues/14515

Introduces a `swag-migration-data-grid-extended` component that extends `sw-data-grid` with a `customSelectionCount` prop, so the counter reflects the total count when "Select all" is active instead of only showing the current selection.