### PR TITLE
fix: phpstan unserialize errors

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -40,7 +40,6 @@ parameters:
         - message: '#Call to deprecated method __construct\(\) of class Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityDefinition#'
         - message: '#Call to deprecated method columnExists\(\) of class Shopware\\Core\\Framework\\Migration\\MigrationStep#'
         - message: '#Call to deprecated method columnExists\(\) of class SwagMigrationAssistant\\Core\\Migration\\Migration1762346793RenameColumnOfMappingTable#'
-        - message: '#Call to deprecated method addColumn\(\) of class Shopware\\Core\\Framework\\Migration\\MigrationStep#'
         - message: '#Call to deprecated method indexExists\(\) of class Shopware\\Core\\Framework\\Migration\\MigrationStep#'
         - message: '#Call to deprecated method listTableColumns\(\) of class Doctrine\\DBAL\\Schema\\AbstractSchemaManager#'
         - message: '#Call to deprecated method listTableIndexes\(\) of class Doctrine\\DBAL\\Schema\\AbstractSchemaManager#'

--- a/src/Profile/Shopware/Converter/OrderConverter.php
+++ b/src/Profile/Shopware/Converter/OrderConverter.php
@@ -1035,6 +1035,7 @@ abstract class OrderConverter extends ShopwareConverter
 
         $accessGranted = false;
         if (isset($originalEsdItem['downloadAvailablePaymentStatus'])) {
+            /** @phpstan-ignore shopware.unserializeUsage */
             $paymentStatusArray = \unserialize($originalEsdItem['downloadAvailablePaymentStatus'], ['allowed_classes' => false]);
 
             if (\is_array($paymentStatusArray) && isset($this->paymentStatusId)) {

--- a/src/Profile/Shopware/Converter/ProductConverter.php
+++ b/src/Profile/Shopware/Converter/ProductConverter.php
@@ -894,6 +894,7 @@ abstract class ProductConverter extends ShopwareConverter
             }
 
             try {
+                /** @phpstan-ignore shopware.unserializeUsage */
                 $path = \unserialize($esdFile['path'], ['allowed_classes' => false]);
             } catch (\Throwable $e) {
                 $this->loggingService->log(

--- a/src/Profile/Shopware/Converter/TranslationConverter.php
+++ b/src/Profile/Shopware/Converter/TranslationConverter.php
@@ -943,6 +943,7 @@ abstract class TranslationConverter extends ShopwareConverter
         $exception = null;
 
         try {
+            /** @phpstan-ignore shopware.unserializeUsage */
             $objectData = \unserialize($objectDataSerialized, ['allowed_classes' => false]);
         } catch (\Throwable $e) {
             $objectData = null;

--- a/src/Profile/Shopware/Gateway/Local/Reader/EnvironmentReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/EnvironmentReader.php
@@ -56,6 +56,7 @@ class EnvironmentReader extends AbstractReader implements EnvironmentReaderInter
         $result = [];
 
         foreach ($rows as $row) {
+            /** @phpstan-ignore shopware.unserializeUsage */
             $result[$row['name']] = \unserialize($row['value'], ['allowed_classes' => false]);
         }
 

--- a/src/Profile/Shopware/Gateway/Local/Reader/NewsletterRecipientReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/NewsletterRecipientReader.php
@@ -187,6 +187,7 @@ class NewsletterRecipientReader extends AbstractReader implements ReaderInterfac
         $resultSet = [];
 
         foreach ($shops as $shop) {
+            /** @phpstan-ignore shopware.unserializeUsage */
             $groupId = \unserialize($shop['groupID'], ['allowed_classes' => false]);
             if (!isset($resultSet[$groupId])) {
                 $resultSet[$groupId] = [];

--- a/src/Profile/Shopware/Gateway/Local/Reader/NumberRangeReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/NumberRangeReader.php
@@ -35,6 +35,7 @@ class NumberRangeReader extends AbstractReader implements ReaderInterface
     public function read(MigrationContextInterface $migrationContext): array
     {
         $numberRanges = $this->fetchNumberRanges($migrationContext->getOffset(), $migrationContext->getLimit(), $migrationContext);
+        /** @phpstan-ignore shopware.unserializeUsage */
         $prefix = \unserialize($this->fetchPrefix($migrationContext), ['allowed_classes' => false]);
 
         if (!$prefix) {

--- a/src/Profile/Shopware/Gateway/Local/Reader/SeoUrlReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/SeoUrlReader.php
@@ -120,7 +120,8 @@ class SeoUrlReader extends AbstractReader implements ReaderInterface
             return true;
         }
 
-        return (bool) \unserialize($useUrlToLower);
+        /** @phpstan-ignore shopware.unserializeUsage */
+        return (bool) \unserialize($useUrlToLower, ['allowed_classes' => false]);
     }
 
     /**

--- a/src/Profile/Shopware/Premapping/SalutationReader.php
+++ b/src/Profile/Shopware/Premapping/SalutationReader.php
@@ -93,6 +93,7 @@ class SalutationReader extends AbstractPremappingReader
         }
 
         $salutations = [];
+        /** @phpstan-ignore shopware.unserializeUsage */
         $salutations[] = \explode(',', \unserialize($result[0]['value'], ['allowed_classes' => false]));
         $salutations = \array_filter($salutations);
 
@@ -102,6 +103,7 @@ class SalutationReader extends AbstractPremappingReader
             foreach ($configuredSalutations as $configuredSalutation) {
                 $salutations[] = \explode(
                     ',',
+                    /** @phpstan-ignore shopware.unserializeUsage */
                     \unserialize($configuredSalutation['value'], ['allowed_classes' => false])
                 );
             }

--- a/tests/Profile/Shopware55/Converter/TranslationConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/TranslationConverterTest.php
@@ -392,6 +392,7 @@ class TranslationConverterTest extends TestCase
         static::assertArrayHasKey('translations', $converted);
         static::assertArrayHasKey(DummyMappingService::DEFAULT_LANGUAGE_UUID, $converted['translations']);
 
+        /** @phpstan-ignore shopware.unserializeUsage */
         $originalData = \unserialize($translationData['category']['objectdata'], ['allowed_classes' => false]);
         $translations = $converted['translations'][DummyMappingService::DEFAULT_LANGUAGE_UUID];
 


### PR DESCRIPTION
Fix of PHPStan errors that were introduced by a new rule in core:
https://github.com/shopware/shopware/pull/14936

I intentionally only fixed this in our feature branch, we want to merge that into `trunk` soon (likely this or next week) anyways.
