### PR TITLE
fix: display nested resolution

### DIFF
--- a/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal/index.ts
@@ -457,12 +457,11 @@ export default Shopware.Component.wrapComponentConfig({
                     this.selectedLog.entityName,
                     entityFieldProperties,
                     convertedData,
-                    this.selectedLog.fieldName,
                 ),
             };
 
             if (hasFixApplied) {
-                row[this.selectedLog.fieldName] = fix.value;
+                Shopware.Utils.object.set(row, this.selectedLog.fieldName, fix.value);
             }
 
             return row;

--- a/src/Resources/app/administration/src/module/swag-migration/service/swag-migration-error-resolution.service.ts
+++ b/src/Resources/app/administration/src/module/swag-migration/service/swag-migration-error-resolution.service.ts
@@ -635,7 +635,7 @@ export default class SwagMigrationErrorResolutionService {
                 finalValue = `${finalValue.substring(0, CONTENT_TEXT_MAX_LENGTH)}...`;
             }
 
-            acc[property] = finalValue;
+            Shopware.Utils.object.set(acc, property, finalValue);
 
             return acc;
         }, {});

--- a/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
+++ b/tests/Jest/src/module/swag-migration/component/swag-migration-error-resolution/swag-migration-error-resolution-modal.spec.js
@@ -639,31 +639,69 @@ describe('module/swag-migration/component/swag-migration-error-resolution/swag-m
 
     describe('create resolution fix', () => {
         it('should save fix when backend validation passes', async () => {
-            migrationApiServiceMock.validateResolution.mockResolvedValueOnce({ valid: true, violations: [] });
+            migrationApiServiceMock.validateResolution.mockResolvedValueOnce({
+                valid: true,
+                violations: [],
+            });
+
+            const nestedLog = {
+                ...logMocks.at(1),
+                convertedData: {
+                    children: {
+                        stock: null,
+                    },
+                    ...logMocks.at(1).convertedData,
+                },
+            };
+
+            migrationLoggingRepositoryMock.search.mockImplementationOnce(() => {
+                const result = [nestedLog];
+                result.total = 1;
+
+                return Promise.resolve(result);
+            });
+
+            migrationFixRepositoryMock.search.mockResolvedValueOnce([]);
+            migrationLoggingRepositoryMock.search.mockImplementationOnce(() => {
+                const result = [nestedLog];
+                result.total = 1;
+
+                return Promise.resolve(result);
+            });
+
+            migrationFixRepositoryMock.search.mockResolvedValueOnce([
+                {
+                    id: 'new-fix-id',
+                    entityId: 'log-entity-id-2',
+                    value: 42,
+                },
+            ]);
 
             const wrapper = await createWrapper({
                 ...defaultProps,
                 selectedLog: {
                     ...fixtureLogGroups.at(1),
-                    entityName: 'media',
-                    fieldName: 'title',
+                    entityName: 'product',
+                    fieldName: 'children.stock',
                 },
             });
             await flushPromises();
 
-            await wrapper.find('.sw-data-grid__row--1 .mt-field--checkbox input').setChecked(true);
+            await wrapper.find('.sw-data-grid__row--0 .mt-field--checkbox input').setChecked(true);
             await flushPromises();
 
             const inputField = wrapper.find('.swag-migration-error-resolution-field-scalar input');
-            await inputField.setValue('Valid Title');
+            await inputField.setValue(42);
             await flushPromises();
 
             await wrapper.find('.swag-migration-error-resolution-modal__right-content-button').trigger('click');
             await flushPromises();
 
-            expect(migrationApiServiceMock.validateResolution).toHaveBeenCalledWith('media', 'title', 'Valid Title');
+            expect(migrationApiServiceMock.validateResolution).toHaveBeenCalledWith('product', 'children.stock', 42);
             expect(wrapper.vm.fieldError).toBeNull();
             expect(migrationFixRepositoryMock.saveAll).toHaveBeenCalled();
+
+            expect(wrapper.vm.tableData[0].children.stock).toBe(42);
         });
 
         it('should not save fix when backend validation fails without message', async () => {

--- a/tests/Jest/src/module/swag-migration/service/swag-migration-error-resolution.service.spec.js
+++ b/tests/Jest/src/module/swag-migration/service/swag-migration-error-resolution.service.spec.js
@@ -827,6 +827,22 @@ const MAP_ENTITY_FIELD_PROPERTIES_TESTS = [
         expected: { id: 'prod-1', name: 'Product 1', productNumber: 'P-001' },
     },
     {
+        name: 'nested field path',
+        entityName: 'product',
+        fieldProperties: [
+            'id',
+            'children.stock',
+        ],
+        convertedData: {
+            id: 'prod-1',
+            children: { stock: 50 },
+        },
+        expected: {
+            id: 'prod-1',
+            children: { stock: 50 },
+        },
+    },
+    {
         name: 'missing properties in data',
         entityName: 'product',
         fieldProperties: [


### PR DESCRIPTION
part of https://github.com/shopware/shopware/issues/15045

fixes the display of nested resolutions like `product.children.stock` (empty before)