### PR TITLE
fix: acceptance test expected entity counts

### DIFF
--- a/tests/acceptance/tests/MigrationTest.spec.ts
+++ b/tests/acceptance/tests/MigrationTest.spec.ts
@@ -229,7 +229,7 @@ test.describe('Migration Tests @migration @visual', () => {
             await EntityCounter.checkEntityCount('order', 2);
             await EntityCounter.checkEntityCount('customer', 3);
 
-            await EntityCounter.checkEntityCount('cms_page', 10);
+            await EntityCounter.checkEntityCount('cms_page', 11);
             await EntityCounter.checkEntityCount('media', 595);
             await EntityCounter.checkEntityCount('media_folder', 24);
             await EntityCounter.checkEntityCount('document', 8);


### PR DESCRIPTION
Looks like the shopware core added a CMS page, likely here:
https://github.com/shopware/shopware/pull/14362

And because we compare absolute entity counts after the migration, that counter for `cms_page` changed and causing a failing acceptance pipeline for us:
https://github.com/shopware/SwagMigrationAssistant/actions/runs/22477261457/job/65107811395

For now I adjusted the count, but for the future we likely want to consider comparing relative numbers (e.g. fetching counts before and after the migration) to be more resistant against such changes. I created an issue for that here: 
https://github.com/shopware/shopware/issues/15245