### PR TITLE
fix: SW6 connection DAL exception

### DIFF
--- a/src/Profile/Shopware6/Gateway/Connection/AuthClient.php
+++ b/src/Profile/Shopware6/Gateway/Connection/AuthClient.php
@@ -129,15 +129,21 @@ class AuthClient implements HttpClientInterface
 
         $connectionUuid = $connection->getId();
         $credentials['bearer_token'] = $this->bearerToken;
+        $connection->setCredentialFields($credentials);
 
-        $this->context->scope(MigrationContext::SOURCE_CONTEXT, function (Context $context) use ($connectionUuid, $credentials): void {
-            $this->connectionRepository->update([
-                [
-                    'id' => $connectionUuid,
-                    'credentialFields' => $credentials,
-                ],
-            ], $context);
-        });
+        try {
+            $this->context->scope(MigrationContext::SOURCE_CONTEXT, function (Context $context) use ($connectionUuid, $credentials): void {
+                $this->connectionRepository->update([
+                    [
+                        'id' => $connectionUuid,
+                        'credentialFields' => $credentials,
+                    ],
+                ], $context);
+            });
+        } catch (\Throwable $e) {
+            // ignore failures here because
+            // the connection might not be persisted to the DB yet
+        }
     }
 
     private function loadBearerToken(): void


### PR DESCRIPTION
With https://github.com/shopware/SwagMigrationAssistant/pull/137 I refactored the logic to only persist the `SwagMigrationConnection` into the DB after it was successfully validated.

But I missed that for SW6 API connections we cache the bearer token and also persist it into the DB. This now failed when you initially try to set up your SW6 connection (because it doesn't exists in the DB yet).