### PR TITLE
chore: add tests for SW6 AuthClient

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -14,10 +14,6 @@ on:
     branches:
       - trunk
   pull_request:
-    paths:
-      - src/**
-      - tests/acceptance/**
-      - .github/workflows/acceptance.yaml
 
 jobs:
   playwright:

--- a/tests/Profile/Shopware6/Gateway/Connection/AuthClientTest.php
+++ b/tests/Profile/Shopware6/Gateway/Connection/AuthClientTest.php
@@ -9,10 +9,14 @@ namespace SwagMigrationAssistant\Test\Profile\Shopware6\Gateway\Connection;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -32,18 +36,15 @@ class AuthClientTest extends TestCase
         $connection = $this->createConnection('existing-token');
         $migrationContext = new MigrationContext($connection);
         $expectedResponse = new Response(SymfonyResponse::HTTP_OK);
+        $apiClient = $this->createApiClientWithResponses([
+            function (RequestInterface $request) use ($expectedResponse): ResponseInterface {
+                static::assertSame('/api/version', (string) $request->getUri());
+                static::assertSame('GET', $request->getMethod());
+                static::assertSame('Bearer existing-token', $request->getHeaderLine('Authorization'));
 
-        $apiClient = $this->createMock(Client::class);
-        $apiClient
-            ->expects($this->once())
-            ->method('get')
-            ->with('/api/version', [
-                'headers' => [
-                    'Authorization' => 'Bearer existing-token',
-                ],
-            ])
-            ->willReturn($expectedResponse);
-        $apiClient->expects($this->never())->method('post');
+                return $expectedResponse;
+            },
+        ]);
 
         $connectionRepository = $this->createConnectionRepositoryMock(0);
         $client = new AuthClient($apiClient, $connectionRepository, $migrationContext, Context::createDefaultContext());
@@ -64,7 +65,10 @@ class AuthClientTest extends TestCase
         $response = $client->get('/api/version');
 
         static::assertSame($expectedResponse, $response);
-        static::assertSame('renewed-token', $connection->getCredentialFields()['bearer_token']);
+        $credentials = $connection->getCredentialFields();
+        static::assertIsArray($credentials);
+        static::assertArrayHasKey('bearer_token', $credentials);
+        static::assertSame('renewed-token', $credentials['bearer_token']);
     }
 
     public function testGetThrowsExceptionOnMissingCredentials(): void
@@ -72,9 +76,8 @@ class AuthClientTest extends TestCase
         $connection = new SwagMigrationConnectionEntity();
         $migrationContext = new MigrationContext($connection);
 
-        $apiClient = $this->createMock(Client::class);
-        /** @var EntityRepository<SwagMigrationConnectionCollection> $connectionRepository */
-        $connectionRepository = $this->createMock(EntityRepository::class);
+        $apiClient = $this->createApiClientWithResponses([]);
+        $connectionRepository = $this->createConnectionRepositoryMock(0);
 
         $client = new AuthClient($apiClient, $connectionRepository, $migrationContext, Context::createDefaultContext());
 
@@ -101,7 +104,10 @@ class AuthClientTest extends TestCase
         $response = $client->get('/api/version');
 
         static::assertSame($expectedResponse, $response);
-        static::assertSame('renewed-token', $connection->getCredentialFields()['bearer_token']);
+        $credentials = $connection->getCredentialFields();
+        static::assertIsArray($credentials);
+        static::assertArrayHasKey('bearer_token', $credentials);
+        static::assertSame('renewed-token', $credentials['bearer_token']);
     }
 
     private function createConnection(string $bearerToken): SwagMigrationConnectionEntity
@@ -123,7 +129,7 @@ class AuthClientTest extends TestCase
      */
     private function createConnectionRepositoryMock(int $expectedUpdateCalls, ?\Throwable $updateException = null): EntityRepository
     {
-        /** @var EntityRepository<SwagMigrationConnectionCollection> $connectionRepository */
+        /** @var EntityRepository<SwagMigrationConnectionCollection>&MockObject $connectionRepository */
         $connectionRepository = $this->createMock(EntityRepository::class);
 
         $updateExpectation = $connectionRepository
@@ -142,7 +148,7 @@ class AuthClientTest extends TestCase
         string $newBearerToken,
         ResponseInterface $expectedResponse
     ): Client {
-        $unauthorizedException = new ClientException(
+        $firstRequestException = new ClientException(
             'Unauthorized',
             new Request('GET', '/api/version'),
             new Response(SymfonyResponse::HTTP_UNAUTHORIZED)
@@ -153,43 +159,45 @@ class AuthClientTest extends TestCase
             (string) json_encode(['access_token' => $newBearerToken])
         );
 
-        $getCallCount = 0;
-        $apiClient = $this->createMock(Client::class);
-        $apiClient
-            ->expects($this->exactly(2))
-            ->method('get')
-            ->willReturnCallback(function (string $uri, array $options) use (
-                &$getCallCount,
-                $unauthorizedException,
-                $oldBearerToken,
-                $newBearerToken,
-                $expectedResponse
-            ): ResponseInterface {
-                ++$getCallCount;
+        return $this->createApiClientWithResponses(
+            [
+                function (RequestInterface $request) use ($oldBearerToken, $firstRequestException): void {
+                    static::assertSame('/api/version', (string) $request->getUri());
+                    static::assertSame('GET', $request->getMethod());
+                    static::assertSame('Bearer ' . $oldBearerToken, $request->getHeaderLine('Authorization'));
 
-                static::assertSame('/api/version', $uri);
+                    throw $firstRequestException;
+                },
+                function (RequestInterface $request) use ($tokenResponse): ResponseInterface {
+                    static::assertSame('/api/oauth/token', (string) $request->getUri());
+                    static::assertSame('POST', $request->getMethod());
+                    static::assertSame(
+                        '{"grant_type":"client_credentials","client_id":"api-user","client_secret":"api-password"}',
+                        (string) $request->getBody()
+                    );
 
-                if ($getCallCount === 1) {
-                    static::assertSame('Bearer ' . $oldBearerToken, $options['headers']['Authorization']);
-                    throw $unauthorizedException;
-                }
+                    return $tokenResponse;
+                },
+                function (RequestInterface $request) use ($newBearerToken, $expectedResponse): ResponseInterface {
+                    static::assertSame('/api/version', (string) $request->getUri());
+                    static::assertSame('GET', $request->getMethod());
+                    static::assertSame('Bearer ' . $newBearerToken, $request->getHeaderLine('Authorization'));
 
-                static::assertSame('Bearer ' . $newBearerToken, $options['headers']['Authorization']);
+                    return $expectedResponse;
+                },
+            ]
+        );
+    }
 
-                return $expectedResponse;
-            });
-        $apiClient
-            ->expects($this->once())
-            ->method('post')
-            ->with('/api/oauth/token', [
-                'json' => [
-                    'grant_type' => 'client_credentials',
-                    'client_id' => 'api-user',
-                    'client_secret' => 'api-password',
-                ],
-            ])
-            ->willReturn($tokenResponse);
+    /**
+     * @param list<\Closure(RequestInterface): ResponseInterface|void> $responses
+     */
+    private function createApiClientWithResponses(array $responses): Client
+    {
+        $handler = HandlerStack::create(new MockHandler($responses));
 
-        return $apiClient;
+        return new Client([
+            'handler' => $handler,
+        ]);
     }
 }

--- a/tests/Profile/Shopware6/Gateway/Connection/AuthClientTest.php
+++ b/tests/Profile/Shopware6/Gateway/Connection/AuthClientTest.php
@@ -1,0 +1,195 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SwagMigrationAssistant\Test\Profile\Shopware6\Gateway\Connection;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Uuid\Uuid;
+use SwagMigrationAssistant\Exception\MigrationException;
+use SwagMigrationAssistant\Migration\Connection\SwagMigrationConnectionCollection;
+use SwagMigrationAssistant\Migration\Connection\SwagMigrationConnectionEntity;
+use SwagMigrationAssistant\Migration\MigrationContext;
+use SwagMigrationAssistant\Profile\Shopware6\Gateway\Connection\AuthClient;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+#[CoversClass(AuthClient::class)]
+class AuthClientTest extends TestCase
+{
+    public function testGetUsesExistingBearerToken(): void
+    {
+        $connection = $this->createConnection('existing-token');
+        $migrationContext = new MigrationContext($connection);
+        $expectedResponse = new Response(SymfonyResponse::HTTP_OK);
+
+        $apiClient = $this->createMock(Client::class);
+        $apiClient
+            ->expects($this->once())
+            ->method('get')
+            ->with('/api/version', [
+                'headers' => [
+                    'Authorization' => 'Bearer existing-token',
+                ],
+            ])
+            ->willReturn($expectedResponse);
+        $apiClient->expects($this->never())->method('post');
+
+        $connectionRepository = $this->createConnectionRepositoryMock(0);
+        $client = new AuthClient($apiClient, $connectionRepository, $migrationContext, Context::createDefaultContext());
+        $response = $client->get('/api/version');
+
+        static::assertSame($expectedResponse, $response);
+    }
+
+    public function testGetRenewsBearerTokenAfterUnauthorizedAndRetries(): void
+    {
+        $connection = $this->createConnection('expired-token');
+        $migrationContext = new MigrationContext($connection);
+        $expectedResponse = new Response(SymfonyResponse::HTTP_OK);
+
+        $apiClient = $this->createApiClientForRenewalFlow('expired-token', 'renewed-token', $expectedResponse);
+        $connectionRepository = $this->createConnectionRepositoryMock(1);
+        $client = new AuthClient($apiClient, $connectionRepository, $migrationContext, Context::createDefaultContext());
+        $response = $client->get('/api/version');
+
+        static::assertSame($expectedResponse, $response);
+        static::assertSame('renewed-token', $connection->getCredentialFields()['bearer_token']);
+    }
+
+    public function testGetThrowsExceptionOnMissingCredentials(): void
+    {
+        $connection = new SwagMigrationConnectionEntity();
+        $migrationContext = new MigrationContext($connection);
+
+        $apiClient = $this->createMock(Client::class);
+        /** @var EntityRepository<SwagMigrationConnectionCollection> $connectionRepository */
+        $connectionRepository = $this->createMock(EntityRepository::class);
+
+        $client = new AuthClient($apiClient, $connectionRepository, $migrationContext, Context::createDefaultContext());
+
+        try {
+            $client->get('/api/version');
+        } catch (MigrationException $e) {
+            static::assertSame(MigrationException::INVALID_CONNECTION_CREDENTIALS, $e->getErrorCode());
+
+            return;
+        }
+
+        static::fail('Expected exception not thrown');
+    }
+
+    public function testGetIgnoresDalFailureWhenSavingRenewedToken(): void
+    {
+        $connection = $this->createConnection('expired-token');
+        $migrationContext = new MigrationContext($connection);
+        $expectedResponse = new Response(SymfonyResponse::HTTP_OK);
+
+        $apiClient = $this->createApiClientForRenewalFlow('expired-token', 'renewed-token', $expectedResponse);
+        $connectionRepository = $this->createConnectionRepositoryMock(1, new \RuntimeException('DAL write failed'));
+        $client = new AuthClient($apiClient, $connectionRepository, $migrationContext, Context::createDefaultContext());
+        $response = $client->get('/api/version');
+
+        static::assertSame($expectedResponse, $response);
+        static::assertSame('renewed-token', $connection->getCredentialFields()['bearer_token']);
+    }
+
+    private function createConnection(string $bearerToken): SwagMigrationConnectionEntity
+    {
+        $connection = new SwagMigrationConnectionEntity();
+        $connection->setId(Uuid::randomHex());
+
+        $connection->setCredentialFields([
+            'apiUser' => 'api-user',
+            'apiPassword' => 'api-password',
+            'bearer_token' => $bearerToken,
+        ]);
+
+        return $connection;
+    }
+
+    /**
+     * @return EntityRepository<SwagMigrationConnectionCollection>
+     */
+    private function createConnectionRepositoryMock(int $expectedUpdateCalls, ?\Throwable $updateException = null): EntityRepository
+    {
+        /** @var EntityRepository<SwagMigrationConnectionCollection> $connectionRepository */
+        $connectionRepository = $this->createMock(EntityRepository::class);
+
+        $updateExpectation = $connectionRepository
+            ->expects($this->exactly($expectedUpdateCalls))
+            ->method('update');
+
+        if ($updateException !== null) {
+            $updateExpectation->willThrowException($updateException);
+        }
+
+        return $connectionRepository;
+    }
+
+    private function createApiClientForRenewalFlow(
+        string $oldBearerToken,
+        string $newBearerToken,
+        ResponseInterface $expectedResponse
+    ): Client {
+        $unauthorizedException = new ClientException(
+            'Unauthorized',
+            new Request('GET', '/api/version'),
+            new Response(SymfonyResponse::HTTP_UNAUTHORIZED)
+        );
+        $tokenResponse = new Response(
+            SymfonyResponse::HTTP_OK,
+            [],
+            (string) json_encode(['access_token' => $newBearerToken])
+        );
+
+        $getCallCount = 0;
+        $apiClient = $this->createMock(Client::class);
+        $apiClient
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnCallback(function (string $uri, array $options) use (
+                &$getCallCount,
+                $unauthorizedException,
+                $oldBearerToken,
+                $newBearerToken,
+                $expectedResponse
+            ): ResponseInterface {
+                ++$getCallCount;
+
+                static::assertSame('/api/version', $uri);
+
+                if ($getCallCount === 1) {
+                    static::assertSame('Bearer ' . $oldBearerToken, $options['headers']['Authorization']);
+                    throw $unauthorizedException;
+                }
+
+                static::assertSame('Bearer ' . $newBearerToken, $options['headers']['Authorization']);
+
+                return $expectedResponse;
+            });
+        $apiClient
+            ->expects($this->once())
+            ->method('post')
+            ->with('/api/oauth/token', [
+                'json' => [
+                    'grant_type' => 'client_credentials',
+                    'client_id' => 'api-user',
+                    'client_secret' => 'api-password',
+                ],
+            ])
+            ->willReturn($tokenResponse);
+
+        return $apiClient;
+    }
+}

--- a/tests/Profile/Shopware6/Gateway/Connection/AuthClientTest.php
+++ b/tests/Profile/Shopware6/Gateway/Connection/AuthClientTest.php
@@ -81,15 +81,9 @@ class AuthClientTest extends TestCase
 
         $client = new AuthClient($apiClient, $connectionRepository, $migrationContext, Context::createDefaultContext());
 
-        try {
-            $client->get('/api/version');
-        } catch (MigrationException $e) {
-            static::assertSame(MigrationException::INVALID_CONNECTION_CREDENTIALS, $e->getErrorCode());
+        static::expectExceptionObject(MigrationException::invalidConnectionCredentials());
 
-            return;
-        }
-
-        static::fail('Expected exception not thrown');
+        $client->get('/api/version');
     }
 
     public function testGetIgnoresDalFailureWhenSavingRenewedToken(): void


### PR DESCRIPTION
Added unit tests for `src/Profile/Shopware6/Gateway/Connection/AuthClient.php`, also specifically one that prevents regressions of the issue fixed here https://github.com/shopware/SwagMigrationAssistant/pull/145

Disclaimer: most of the code was generated by Codex