### PR TITLE
chore: fix typescript types and migration api service

### DIFF
--- a/src/Resources/app/administration/src/core/service/api/swag-migration.api.service.ts
+++ b/src/Resources/app/administration/src/core/service/api/swag-migration.api.service.ts
@@ -78,9 +78,9 @@ export default class MigrationApiService extends ApiService {
         connectionName: string,
         profileName: string,
         gatewayName: string,
-        credentialFields: Record<string, MigrationCredentials>,
+        credentialFields: MigrationCredentials,
         additionalHeaders: AdditionalHeaders = {},
-    ): Promise<ApiResponse<unknown>> {
+    ): Promise<ApiResponse<MigrationEnvironmentInformation>> {
         // @ts-ignore
         const headers = this.getBasicHeaders(additionalHeaders);
 
@@ -108,9 +108,9 @@ export default class MigrationApiService extends ApiService {
 
     async updateConnectionCredentials(
         connectionId: string,
-        credentialFields: Record<string, MigrationCredentials>,
+        credentialFields: MigrationCredentials,
         additionalHeaders: AdditionalHeaders = {},
-    ): Promise<ApiResponse<unknown>> {
+    ): Promise<ApiResponse<MigrationEnvironmentInformation>> {
         // @ts-ignore
         const headers = this.getBasicHeaders(additionalHeaders);
 
@@ -577,7 +577,7 @@ export default class MigrationApiService extends ApiService {
         fieldName: string,
         connectionId?: string,
         additionalHeaders: AdditionalHeaders = {},
-    ): Promise<{ count: int; limit: int }> {
+    ): Promise<{ count: number; limit: number }> {
         // @ts-ignore
         const headers = this.getBasicHeaders(additionalHeaders);
 
@@ -608,7 +608,7 @@ export default class MigrationApiService extends ApiService {
         code: string,
         entityName: string,
         fieldName: string,
-        limit?: int,
+        limit?: number,
         connectionId?: string,
         additionalHeaders: AdditionalHeaders = {},
     ): Promise<{ entityIds: string[] }> {

--- a/src/Resources/app/administration/src/core/service/api/swag-migration.api.service.ts
+++ b/src/Resources/app/administration/src/core/service/api/swag-migration.api.service.ts
@@ -56,6 +56,9 @@ export type LogLevelCounts = {
     info: number;
 };
 
+// todo: remove me, this is just to test our typescript linting
+export const aNumber: string = 42;
+
 /**
  * @private
  * @sw-package fundamentals@after-sales

--- a/src/Resources/app/administration/src/type/types.d.ts
+++ b/src/Resources/app/administration/src/type/types.d.ts
@@ -96,12 +96,7 @@ type MigrationPremapping = {
     mapping: MigrationPremappingEntity[];
 };
 
-type MigrationCredentials = {
-    endpoint: string;
-    apiUser?: string;
-    apiKey?: string;
-    apiPassword?: string;
-};
+type MigrationCredentials = Record<string, string | number | boolean | null>;
 
 type MigrationConnection = {
     id: string;


### PR DESCRIPTION
Looks like our Typescript setup in our plugin is a little broken right now.

I tried to clean up some wrong types a little bit, but ideally I would also like to:
- remove all `@ts-ignore` comments in `swag-migration.api.service.ts`
- somehow import the `ApiService` type from the core, without importing code into our bundle. So we get proper type information for all the methods / fields of the base class
- make sure TSC / Eslint checks types with the `composer run lint:admin` command as well as in our CI

