### PR TITLE
fix: decrease log size by removing trace args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 16.0.1
+
+- Reduced log file size by removing exception trace args
+
 # 16.0.0
 
 - #14517 - Fixed duplicate key error when re-migrating products with SEO main categories after checksum reset

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,7 @@
+# 16.0.1
+
+- Größe der Protokolldatei reduziert, indem Exception-Trace Argumente entfernt wurden
+
 # 16.0.0
 
 - #14517 - Fehler bei doppeltem Schlüssel beim erneuten Migrieren von Produkten mit SEO-Hauptkategorien nach dem Zurücksetzen der Prüfsummen behoben

--- a/src/Migration/Logging/Log/Builder/MigrationLogBuilder.php
+++ b/src/Migration/Logging/Log/Builder/MigrationLogBuilder.php
@@ -128,6 +128,13 @@ class MigrationLogBuilder
     {
         \assert(\class_exists($logClass) && \is_subclass_of($logClass, AbstractMigrationLogEntry::class));
 
+        if ($this->exceptionTrace !== null) {
+            // remove args from trace, as they quickly become too large
+            foreach ($this->exceptionTrace as &$trace) {
+                unset($trace['args']);
+            }
+        }
+
         return new $logClass(
             $this->runId,
             $this->profileName,

--- a/tests/unit/Migration/Logging/Log/MigrationLogTest.php
+++ b/tests/unit/Migration/Logging/Log/MigrationLogTest.php
@@ -86,7 +86,11 @@ class MigrationLogTest extends TestCase
             ->withSourceData(['test' => 'test4'])
             ->withConvertedData(['test' => 'test5'])
             ->withExceptionMessage('test7')
-            ->withExceptionTrace(['test' => 'test8'])
+            ->withExceptionTrace([[
+                'file' => 'test8',
+                'line' => 123,
+                'args' => ['something'],
+            ]])
             ->withEntityId($entityId)
             ->build($logClass);
 
@@ -100,7 +104,10 @@ class MigrationLogTest extends TestCase
         static::assertSame(['test' => 'test4'], $logEntry->getSourceData());
         static::assertSame(['test' => 'test5'], $logEntry->getConvertedData());
         static::assertSame('test7', $logEntry->getExceptionMessage());
-        static::assertSame(['test' => 'test8'], $logEntry->getExceptionTrace());
+        static::assertSame([[
+            'file' => 'test8',
+            'line' => 123,
+        ]], $logEntry->getExceptionTrace());
         static::assertSame($entityId, $logEntry->getEntityId());
     }
 


### PR DESCRIPTION
The migration log files can quickly get huge. For example I had a migration run with around 1000 exceptions, which produced a 1.2 GB log file.

With this adjustment a similar run only produces a log file of around 10 MB instead.

I don't think we lose much context by removing the trace args, often they are just the whole converted array to be written, which we already include elsewhere in the log.