### PR TITLE
ci: update store workflow to use client credentials

### DIFF
--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -7,6 +7,6 @@ jobs:
     with:
       extensionName: ${{ github.event.repository.name }}
     secrets:
-      accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
-      accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
+      clientId: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_ID }}
+      clientSecret: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET }}
       ghToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Migrate the store release workflow from account user/password authentication to client ID/secret credentials
- Replace `accountUser` / `accountPassword` secrets with `clientId` / `clientSecret`
- Reference the new `SHOPWARE_CLI_ACCOUNT_CLIENT_ID` and `SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET` repository secrets

## Test plan
- [x] Verify that the `SHOPWARE_CLI_ACCOUNT_CLIENT_ID` and `SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET` secrets are configured in the repository settings
- [ ] Trigger the "Release to Store" workflow manually and confirm it authenticates successfully with the new credentials