### PR TITLE
fix: nightly

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -56,6 +56,9 @@ parameters:
         - identifier: parameterByRef.type
           path: src/Profile/Shopware/Converter/ShippingMethodConverter.php
 
+        # TODO: https://github.com/shopware/shopware/issues/16031
+        - identifier: empty.notAllowed
+
 rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Deprecation\DeprecatedMethodsThrowDeprecationRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\CoversAttributeRule

--- a/tests/Profile/Shopware55/Converter/TranslationConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/TranslationConverterTest.php
@@ -393,14 +393,12 @@ class TranslationConverterTest extends TestCase
         static::assertArrayHasKey('translations', $converted);
         static::assertArrayHasKey(DummyMappingService::DEFAULT_LANGUAGE_UUID, $converted['translations']);
 
-        /** @phpstan-ignore shopware.unserializeUsage */
-        $originalData = \unserialize($translationData['category']['objectdata'], ['allowed_classes' => false]);
         $translations = $converted['translations'][DummyMappingService::DEFAULT_LANGUAGE_UUID];
 
-        static::assertSame($originalData['description'], $translations['name']);
-        static::assertSame($originalData['cmstext'], $translations['description']);
-        static::assertSame($originalData['external'], $translations['externalLink']);
-        static::assertSame($originalData['metatitle'], $translations['metaTitle']);
+        static::assertSame('Fashion', $translations['name']);
+        static::assertSame('<p>english category description</p>', $translations['description']);
+        static::assertSame('english external', $translations['externalLink']);
+        static::assertSame('english meta title', $translations['metaTitle']);
     }
 
     public function testConvertCategoryAttributeTranslation(): void


### PR DESCRIPTION
nightly fail: https://github.com/shopware/SwagMigrationAssistant/actions/runs/24167848822

created a separat ticket for fixing the `empty` phpstan issue: https://github.com/shopware/shopware/issues/16031