### PR TITLE
fix: skip malformed relation records with missing root id

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    reviewers:
-      - "shopware/product-cc-after-sales"
-    commit-message:
-      prefix: "chore"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      reviewers:
+          - 'shopware/product-cc-after-sales'
+      commit-message:
+          prefix: 'chore'
+      groups:
+          github-actions:
+              patterns:
+                  - '*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # NEXT
 
 - #15568 - Switched to PHP Symfony service definitions
+- Fixed a migration issue where malformed relation records with missing root IDs could abort the run during cleanup and leave it stuck
 
 # 16.1.1
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,7 @@
 # NEXT
 
 - #15568 - Umstellung auf PHP-Symfony-Service-Definitionen
+- Ein Migrationsfehler wurde behoben, bei dem fehlerhafte Relationsdatensätze ohne Root-ID den Lauf während des Aufräumens abbrechen lassen und blockieren konnten
 
 # 16.1.1
 

--- a/src/Migration/ErrorResolution/MigrationErrorResolutionService.php
+++ b/src/Migration/ErrorResolution/MigrationErrorResolutionService.php
@@ -83,7 +83,14 @@ readonly class MigrationErrorResolutionService
      */
     private function loadFixes(MigrationErrorResolutionContext $errorResolutionContext): void
     {
-        $itemIds = \array_column($errorResolutionContext->getData(), 'id');
+        $itemIds = \array_values(
+            array_filter(
+                \array_column($errorResolutionContext->getData(), 'id'),
+                static function ($itemId): bool {
+                    return \is_string($itemId) && $itemId !== '' && Uuid::isValid($itemId);
+                }
+            )
+        );
 
         if (empty($itemIds)) {
             $errorResolutionContext->setFixes([]);

--- a/src/Migration/ErrorResolution/MigrationErrorResolutionService.php
+++ b/src/Migration/ErrorResolution/MigrationErrorResolutionService.php
@@ -56,7 +56,11 @@ readonly class MigrationErrorResolutionService
         $data = $errorResolutionContext->getData();
 
         foreach ($data as &$item) {
-            $id = $item['id'];
+            $id = $item['id'] ?? null;
+
+            if (!\is_string($id) || $id === '' || !Uuid::isValid($id)) {
+                continue;
+            }
 
             if (!\array_key_exists($id, $fixes) || !\is_array($fixes[$id])) {
                 continue;
@@ -84,11 +88,9 @@ readonly class MigrationErrorResolutionService
     private function loadFixes(MigrationErrorResolutionContext $errorResolutionContext): void
     {
         $itemIds = \array_values(
-            array_filter(
+            \array_filter(
                 \array_column($errorResolutionContext->getData(), 'id'),
-                static function ($itemId): bool {
-                    return \is_string($itemId) && $itemId !== '' && Uuid::isValid($itemId);
-                }
+                static fn (mixed $itemId): bool => \is_string($itemId) && $itemId !== '' && Uuid::isValid($itemId)
             )
         );
 

--- a/src/Profile/Shopware/Converter/MainVariantRelationConverter.php
+++ b/src/Profile/Shopware/Converter/MainVariantRelationConverter.php
@@ -13,6 +13,7 @@ use SwagMigrationAssistant\Exception\MigrationException;
 use SwagMigrationAssistant\Migration\Converter\ConvertStruct;
 use SwagMigrationAssistant\Migration\DataSelection\DefaultEntities;
 use SwagMigrationAssistant\Migration\Logging\Log\Builder\MigrationLogBuilder;
+use SwagMigrationAssistant\Migration\Logging\Log\ConvertAssociationMissingLog;
 use SwagMigrationAssistant\Migration\Logging\Log\ConvertMainVariantRelationFailedLog;
 use SwagMigrationAssistant\Migration\MigrationContextInterface;
 
@@ -48,19 +49,35 @@ abstract class MainVariantRelationConverter extends ShopwareConverter
             return new ConvertStruct(null, $data);
         }
 
+        $mainProductMapping = $this->mappingService->getMapping(
+            $this->connectionId,
+            DefaultEntities::PRODUCT_CONTAINER,
+            $data['id'],
+            $context
+        );
+
+        if (
+            $mainProductMapping === null
+            || !\is_string($mainProductMapping['entityId'] ?? null)
+            || $mainProductMapping['entityId'] === ''
+        ) {
+            $this->loggingService->log(
+                MigrationLogBuilder::fromMigrationContext($migrationContext)
+                    ->withEntityName(DefaultEntities::MAIN_VARIANT_RELATION)
+                    ->withFieldName('id')
+                    ->withSourceData($data)
+                    ->build(ConvertAssociationMissingLog::class)
+            );
+
+            return new ConvertStruct(null, $data);
+        }
+
         $this->mainMapping = $this->mappingService->getOrCreateMapping(
             $this->connectionId,
             DefaultEntities::MAIN_VARIANT_RELATION,
             $data['id'],
             $context,
             $this->checksum
-        );
-
-        $mainProductMapping = $this->mappingService->getMapping(
-            $this->connectionId,
-            DefaultEntities::PRODUCT_CONTAINER,
-            $data['id'],
-            $context
         );
 
         $variantProductMapping = $this->mappingService->getMapping(
@@ -70,12 +87,8 @@ abstract class MainVariantRelationConverter extends ShopwareConverter
             $context
         );
 
-        $mainProductId = null;
-
-        if ($mainProductMapping !== null) {
-            $this->mappingIds[] = $mainProductMapping['id'];
-            $mainProductId = $mainProductMapping['entityId'];
-        }
+        $this->mappingIds[] = $mainProductMapping['id'];
+        $mainProductId = $mainProductMapping['entityId'];
 
         $variantProductId = null;
         if ($variantProductMapping !== null) {

--- a/src/Profile/Shopware/Converter/ProductConverter.php
+++ b/src/Profile/Shopware/Converter/ProductConverter.php
@@ -245,6 +245,7 @@ abstract class ProductConverter extends ShopwareConverter
 
                 if (isset($coverMediaUuid) && $media['media']['id'] === $coverMediaUuid) {
                     $converted['children'][0]['cover'] = $media;
+                    $converted['children'][0]['coverId'] = $media['id'];
                 }
             }
         }
@@ -410,6 +411,7 @@ abstract class ProductConverter extends ShopwareConverter
 
             if (isset($convertedMedia['cover'])) {
                 $converted['cover'] = $convertedMedia['cover'];
+                $converted['coverId'] = $convertedMedia['cover']['id'];
             }
 
             unset($data['assets'], $convertedMedia);
@@ -1022,6 +1024,7 @@ abstract class ProductConverter extends ShopwareConverter
             );
             $newMedia['id'] = $mapping['entityId'];
             $this->mappingIds[] = $mapping['id'];
+            $newProductMedia['mediaId'] = $newMedia['id'];
 
             if (empty($mediaData['media']['name'])) {
                 $mediaData['media']['name'] = $newMedia['id'];

--- a/src/Profile/Shopware/Converter/ProductOptionRelationConverter.php
+++ b/src/Profile/Shopware/Converter/ProductOptionRelationConverter.php
@@ -12,6 +12,8 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use SwagMigrationAssistant\Migration\Converter\ConvertStruct;
 use SwagMigrationAssistant\Migration\DataSelection\DefaultEntities;
+use SwagMigrationAssistant\Migration\Logging\Log\Builder\MigrationLogBuilder;
+use SwagMigrationAssistant\Migration\Logging\Log\ConvertAssociationMissingLog;
 use SwagMigrationAssistant\Migration\MigrationContextInterface;
 
 #[Package('fundamentals@after-sales')]
@@ -44,11 +46,24 @@ abstract class ProductOptionRelationConverter extends ShopwareConverter
             $context
         );
 
-        $productContainerId = null;
-        if ($productContainerMapping !== null) {
-            $this->mappingIds[] = $productContainerMapping['id'];
-            $productContainerId = $productContainerMapping['entityId'];
+        if (
+            $productContainerMapping === null
+            || !\is_string($productContainerMapping['entityId'] ?? null)
+            || $productContainerMapping['entityId'] === ''
+        ) {
+            $this->loggingService->log(
+                MigrationLogBuilder::fromMigrationContext($migrationContext)
+                    ->withEntityName(DefaultEntities::PRODUCT_OPTION_RELATION)
+                    ->withFieldName('productId')
+                    ->withSourceData($data)
+                    ->build(ConvertAssociationMissingLog::class)
+            );
+
+            return new ConvertStruct(null, $data);
         }
+
+        $this->mappingIds[] = $productContainerMapping['id'];
+        $productContainerId = $productContainerMapping['entityId'];
 
         $optionMapping = $this->mappingService->getMapping(
             $this->connectionId,

--- a/src/Profile/Shopware/Converter/ProductPropertyRelationConverter.php
+++ b/src/Profile/Shopware/Converter/ProductPropertyRelationConverter.php
@@ -71,6 +71,21 @@ abstract class ProductPropertyRelationConverter extends ShopwareConverter
             return new ConvertStruct(null, $data);
         }
 
+        if (
+            !\is_string($productMapping['entityId'] ?? null)
+            || $productMapping['entityId'] === ''
+        ) {
+            $this->loggingService->log(
+                MigrationLogBuilder::fromMigrationContext($migrationContext)
+                    ->withEntityName(PropertyGroupOptionDefinition::ENTITY_NAME)
+                    ->withFieldName('productId')
+                    ->withSourceData($data)
+                    ->build(ConvertAssociationMissingLog::class)
+            );
+
+            return new ConvertStruct(null, $data);
+        }
+
         $this->mappingIds[] = $productMapping['id'];
 
         $optionMapping = $this->mappingService->getMapping(
@@ -92,7 +107,7 @@ abstract class ProductPropertyRelationConverter extends ShopwareConverter
         );
 
         $converted = [];
-        $converted['id'] = $productMapping['entityId'] ?? null;
+        $converted['id'] = $productMapping['entityId'];
         $converted['properties'][] = [
             'id' => $optionMapping['entityId'] ?? null,
         ];

--- a/tests/Profile/Shopware55/Converter/MainVariantRelationConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/MainVariantRelationConverterTest.php
@@ -130,4 +130,26 @@ class MainVariantRelationConverterTest extends TestCase
         static::assertSame($this->productContainer2['entityId'], $converted['id']);
         static::assertSame($this->productVariant2['entityId'], $converted['variantListingConfig']['mainVariantId']);
     }
+
+    public function testConvertReturnsNullIfMainProductMappingIsMissing(): void
+    {
+        $context = Context::createDefaultContext();
+        $mappingService = new DummyMappingService();
+        $converter = new Shopware55MainVariantRelationConverter($mappingService, new DummyLoggingService());
+        $connectionId = $this->migrationContext->getConnection()->getId();
+        $data = require __DIR__ . '/../../../_fixtures/main_variant_relation.php';
+
+        $mappingService->getOrCreateMapping(
+            $connectionId,
+            DefaultEntities::PRODUCT,
+            $data[0]['ordernumber'],
+            $context
+        );
+
+        $convertResult = $converter->convert($data[0], $context, $this->migrationContext);
+
+        static::assertNull($convertResult->getConverted());
+        static::assertSame($data[0], $convertResult->getUnmapped());
+        static::assertNull($convertResult->getMappingUuid());
+    }
 }

--- a/tests/Profile/Shopware55/Converter/ProductConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/ProductConverterTest.php
@@ -112,6 +112,8 @@ class ProductConverterTest extends TestCase
         );
         static::assertSame([], $converted['categories']);
         static::assertSame($productData[0]['assets'][0]['description'], $converted['media'][0]['media']['alt']);
+        static::assertSame($converted['media'][0]['media']['id'], $converted['media'][0]['mediaId']);
+        static::assertSame($converted['cover']['id'], $converted['coverId']);
         static::assertCount(0, $this->loggingService->getLoggingArray());
     }
 
@@ -250,6 +252,8 @@ class ProductConverterTest extends TestCase
         static::assertSame([], $converted['categories']);
         static::assertArrayNotHasKey('options', $converted);
         static::assertArrayHasKey('options', $converted['children'][0]);
+        static::assertSame($converted['children'][0]['cover']['id'], $converted['children'][0]['coverId']);
+        static::assertSame($converted['children'][0]['media'][0]['media']['id'], $converted['children'][0]['media'][0]['mediaId']);
         static::assertCount(0, $this->loggingService->getLoggingArray());
     }
 
@@ -275,11 +279,14 @@ class ProductConverterTest extends TestCase
         static::assertArrayHasKey('media', $converted);
         static::assertCount(2, $converted['media']);
         static::assertSame('hemd', $converted['media'][0]['media']['title']);
+        static::assertSame($converted['media'][0]['media']['id'], $converted['media'][0]['mediaId']);
         static::assertSame(2, $converted['media'][0]['position']);
         static::assertSame('hemd1', $converted['media'][1]['media']['title']);
+        static::assertSame($converted['media'][1]['media']['id'], $converted['media'][1]['mediaId']);
         static::assertSame(1, $converted['media'][1]['position']);
         static::assertArrayHasKey('cover', $converted);
         static::assertSame('hemd1', $converted['cover']['media']['title']);
+        static::assertSame($converted['cover']['id'], $converted['coverId']);
 
         static::assertSame($convertedContainer['id'], $converted['parentId']);
         static::assertCount(0, $this->loggingService->getLoggingArray());
@@ -314,11 +321,14 @@ class ProductConverterTest extends TestCase
         static::assertArrayHasKey('media', $converted);
         static::assertCount(2, $converted['media']);
         static::assertSame('hemd', $converted['media'][0]['media']['title']);
+        static::assertSame($converted['media'][0]['media']['id'], $converted['media'][0]['mediaId']);
         static::assertSame(2, $converted['media'][0]['position']);
         static::assertSame('hemd1', $converted['media'][1]['media']['title']);
+        static::assertSame($converted['media'][1]['media']['id'], $converted['media'][1]['mediaId']);
         static::assertSame(1, $converted['media'][1]['position']);
         static::assertArrayHasKey('cover', $converted);
         static::assertSame('hemd', $converted['cover']['media']['title']);
+        static::assertSame($converted['cover']['id'], $converted['coverId']);
     }
 
     public function testConvertVariantProductWithoutParent(): void

--- a/tests/Profile/Shopware55/Converter/ProductOptionRelationConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/ProductOptionRelationConverterTest.php
@@ -155,4 +155,26 @@ class ProductOptionRelationConverterTest extends TestCase
         static::assertSame($this->propertyUuids[0], $converted['configuratorSettings'][0]['optionId']);
         static::assertSame($this->oldMappingId, $converted['configuratorSettings'][0]['id']);
     }
+
+    public function testConvertReturnsNullIfProductContainerMappingIsMissing(): void
+    {
+        $context = Context::createDefaultContext();
+        $mappingService = new DummyMappingService();
+        $converter = new Shopware55ProductOptionRelationConverter($mappingService, new DummyLoggingService());
+        $connectionId = $this->migrationContext->getConnection()->getId();
+        $data = require __DIR__ . '/../../../_fixtures/product_option_relation.php';
+
+        $mappingService->getOrCreateMapping(
+            $connectionId,
+            DefaultEntities::PROPERTY_GROUP_OPTION,
+            Hasher::hash(\mb_strtolower($data[0]['name'] . '_' . $data[0]['group']['name']), 'md5'),
+            $context
+        );
+
+        $convertResult = $converter->convert($data[0], $context, $this->migrationContext);
+
+        static::assertNull($convertResult->getConverted());
+        static::assertSame($data[0], $convertResult->getUnmapped());
+        static::assertNull($convertResult->getMappingUuid());
+    }
 }

--- a/tests/unit/Migration/ErrorResolution/MigrationErrorResolutionServiceTest.php
+++ b/tests/unit/Migration/ErrorResolution/MigrationErrorResolutionServiceTest.php
@@ -121,6 +121,24 @@ class MigrationErrorResolutionServiceTest extends TestCase
                     ],
                 ],
             ],
+            4 => [
+                'id' => null,
+                'name' => 'test',
+                'the' => ['path' => ['to' => ['value' => 'oldValue']]],
+                'other' => ['path' => ['to' => ['value' => 'oldValue']]],
+            ],
+            5 => [
+                'id' => '',
+                'name' => 'test',
+                'the' => ['path' => ['to' => ['value' => 'oldValue']]],
+                'other' => ['path' => ['to' => ['value' => 'oldValue']]],
+            ],
+            6 => [
+                'id' => 'notValidUuid',
+                'name' => 'test',
+                'the' => ['path' => ['to' => ['value' => 'oldValue']]],
+                'other' => ['path' => ['to' => ['value' => 'oldValue']]],
+            ],
         ];
 
         $eventClasses = [];
@@ -132,7 +150,7 @@ class MigrationErrorResolutionServiceTest extends TestCase
                 return $event;
             });
 
-        $migrationFixApplier = new MigrationErrorResolutionService($this->createConnection($fixes), $eventDispatcher);
+        $migrationFixApplier = new MigrationErrorResolutionService($this->createConnection($fixes, [$dataIdOne, $dataIdTwo, $dataIdThree, $dataIdFour]), $eventDispatcher);
 
         $migrationFixApplier->applyFixes($data, Uuid::randomHex(), Uuid::randomHex(), Context::createDefaultContext());
 
@@ -166,11 +184,18 @@ class MigrationErrorResolutionServiceTest extends TestCase
 
     /**
      * @param array<int, array<string, string>> $fixes
+     * @param array<int, string> $allowedDataIds
      */
-    private function createConnection(array $fixes): Connection
+    private function createConnection(array $fixes, array $allowedDataIds): Connection
     {
         $connectionMock = $this->createMock(Connection::class);
-        $connectionMock->method('fetchAllAssociative')->willReturn($fixes);
+        $connectionMock->method('fetchAllAssociative')->willReturnCallback(
+            function (string $query, array $params = []) use ($fixes, $allowedDataIds) {
+                static::assertSame($params['ids'], Uuid::fromHexToBytesList($allowedDataIds));
+
+                return $fixes;
+            }
+        );
 
         return $connectionMock;
     }

--- a/tests/unit/Migration/ErrorResolution/MigrationErrorResolutionServiceTest.php
+++ b/tests/unit/Migration/ErrorResolution/MigrationErrorResolutionServiceTest.php
@@ -190,7 +190,7 @@ class MigrationErrorResolutionServiceTest extends TestCase
     {
         $connectionMock = $this->createMock(Connection::class);
         $connectionMock->method('fetchAllAssociative')->willReturnCallback(
-            function (string $query, array $params = []) use ($fixes, $allowedDataIds) {
+            static function (string $query, array $params = []) use ($fixes, $allowedDataIds) {
                 static::assertSame($params['ids'], Uuid::fromHexToBytesList($allowedDataIds));
 
                 return $fixes;


### PR DESCRIPTION
These fixes results from the support ticket #SWAG-327644 & #SWAG-328077

Fix 1: The cover image in products is not set. 
Fix 2: Null or invalid FIX IDs break the migration queue.