### PR TITLE
fix: customer language mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NEXT
+
+- Fixed Shopware 5 customer migration with custom locales by resolving `languageId` from existing migration mappings during the same run
+
 # 16.2.0
 
 - #15568 - Switched to PHP Symfony service definitions

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,7 @@
+# NEXT
+
+- Fehler bei der Migration von Shopware-5-Kunden mit benutzerdefinierten Sprachen behoben, indem die `languageId` im selben Lauf aus vorhandenen Migrations-Mappings aufgelöst wird
+
 # 16.2.0
 
 - #15568 - Umstellung auf PHP-Symfony-Service-Definitionen

--- a/src/Profile/Shopware/Converter/CustomerConverter.php
+++ b/src/Profile/Shopware/Converter/CustomerConverter.php
@@ -218,7 +218,12 @@ abstract class CustomerConverter extends ShopwareConverter
         unset($data['attributes']);
 
         if (isset($data['customerlanguage']['locale'])) {
-            $languageUuid = $this->resolveLanguageId($data['customerlanguage']['locale'], $context, $this->languageLookup);
+            $languageUuid = $this->resolveLanguageId(
+                $data['customerlanguage']['locale'],
+                $this->languageLookup,
+                $context,
+            );
+
             if ($languageUuid !== null) {
                 $converted['languageId'] = $languageUuid;
             }
@@ -331,8 +336,10 @@ abstract class CustomerConverter extends ShopwareConverter
                 $address['id'],
                 $this->context
             );
+
             $newAddress['id'] = $addressMapping['entityId'];
             $this->mappingIds[] = $addressMapping['id'];
+
             if ($salutationUuid !== null) {
                 $newAddress['salutationId'] = $salutationUuid;
             }

--- a/src/Profile/Shopware/Converter/CustomerConverter.php
+++ b/src/Profile/Shopware/Converter/CustomerConverter.php
@@ -218,7 +218,7 @@ abstract class CustomerConverter extends ShopwareConverter
         unset($data['attributes']);
 
         if (isset($data['customerlanguage']['locale'])) {
-            $languageUuid = $this->languageLookup->get($data['customerlanguage']['locale'], $context);
+            $languageUuid = $this->resolveLanguageId($data['customerlanguage']['locale'], $context, $this->languageLookup);
             if ($languageUuid !== null) {
                 $converted['languageId'] = $languageUuid;
             }

--- a/src/Profile/Shopware/Converter/CustomerConverter.php
+++ b/src/Profile/Shopware/Converter/CustomerConverter.php
@@ -325,10 +325,6 @@ abstract class CustomerConverter extends ShopwareConverter
             $newAddress = [];
             $salutationUuid = $this->getSalutation($address['salutation']);
 
-            if ($salutationUuid === null) {
-                continue;
-            }
-
             $addressMapping = $this->mappingService->getOrCreateMapping(
                 $this->connectionId,
                 DefaultEntities::CUSTOMER_ADDRESS,
@@ -337,7 +333,9 @@ abstract class CustomerConverter extends ShopwareConverter
             );
             $newAddress['id'] = $addressMapping['entityId'];
             $this->mappingIds[] = $addressMapping['id'];
-            $newAddress['salutationId'] = $salutationUuid;
+            if ($salutationUuid !== null) {
+                $newAddress['salutationId'] = $salutationUuid;
+            }
 
             if (isset($originalData['default_billing_address_id']) && $address['id'] === $originalData['default_billing_address_id']) {
                 $converted['defaultBillingAddressId'] = $newAddress['id'];

--- a/src/Profile/Shopware/Converter/ShopwareConverter.php
+++ b/src/Profile/Shopware/Converter/ShopwareConverter.php
@@ -11,6 +11,8 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use SwagMigrationAssistant\Migration\Connection\Helper\ConnectionNameSanitizer;
 use SwagMigrationAssistant\Migration\Converter\Converter;
+use SwagMigrationAssistant\Migration\DataSelection\DefaultEntities;
+use SwagMigrationAssistant\Migration\Mapping\Lookup\LanguageLookup;
 use SwagMigrationAssistant\Migration\MigrationContextInterface;
 
 #[Package('fundamentals@after-sales')]
@@ -28,6 +30,24 @@ abstract class ShopwareConverter extends Converter
     public function getSourceIdentifier(array $data): string
     {
         return $data['id'];
+    }
+
+    protected function resolveLanguageId(string $locale, Context $context, LanguageLookup $languageLookup): ?string
+    {
+        $mapping = $this->mappingService->getMapping(
+            $this->migrationContext->getConnection()->getId(),
+            DefaultEntities::LANGUAGE,
+            $locale,
+            $context
+        );
+
+        if (isset($mapping['entityId'])) {
+            $this->mappingIds[] = $mapping['id'];
+
+            return $mapping['entityId'];
+        }
+
+        return $languageLookup->get($locale, $context);
     }
 
     /**

--- a/src/Profile/Shopware/Converter/ShopwareConverter.php
+++ b/src/Profile/Shopware/Converter/ShopwareConverter.php
@@ -32,7 +32,7 @@ abstract class ShopwareConverter extends Converter
         return $data['id'];
     }
 
-    protected function resolveLanguageId(string $locale, Context $context, LanguageLookup $languageLookup): ?string
+    protected function resolveLanguageId(string $locale, LanguageLookup $languageLookup, Context $context): ?string
     {
         $mapping = $this->mappingService->getMapping(
             $this->migrationContext->getConnection()->getId(),

--- a/src/Profile/Shopware/Gateway/Local/Reader/LanguageReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/LanguageReader.php
@@ -81,7 +81,7 @@ class LanguageReader extends AbstractReader implements ReaderInterface
     }
 
     /**
-     * @return list<mixed>
+     * @return list<string>
      */
     private function fetchCustomerLocaleIds(MigrationContextInterface $migrationContext): array
     {
@@ -89,6 +89,7 @@ class LanguageReader extends AbstractReader implements ReaderInterface
         $query = $connection->createQueryBuilder();
         $query->from('s_user', 'customer');
         $query->addSelect('customer.language');
+        $query->distinct();
         $query->where('customer.language IS NOT NULL');
 
         return $query->executeQuery()->fetchFirstColumn();

--- a/src/Profile/Shopware/Gateway/Local/Reader/LanguageReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/LanguageReader.php
@@ -40,7 +40,10 @@ class LanguageReader extends AbstractReader implements ReaderInterface
 
     public function read(MigrationContextInterface $migrationContext): array
     {
-        $fetchedShopLocaleIds = \array_unique($this->fetchShopLocaleIds($migrationContext));
+        $fetchedShopLocaleIds = \array_unique(\array_merge(
+            $this->fetchShopLocaleIds($migrationContext),
+            $this->fetchCustomerLocaleIds($migrationContext)
+        ));
         $locales = $this->fetchLocales($fetchedShopLocaleIds, $migrationContext);
 
         return $this->appendAssociatedData($locales, $migrationContext);
@@ -74,6 +77,17 @@ class LanguageReader extends AbstractReader implements ReaderInterface
         $query = $query->executeQuery();
 
         return $query->fetchFirstColumn();
+    }
+
+    private function fetchCustomerLocaleIds(MigrationContextInterface $migrationContext): array
+    {
+        $connection = $this->getConnection($migrationContext);
+        $query = $connection->createQueryBuilder();
+        $query->from('s_user', 'customer');
+        $query->addSelect('customer.language');
+        $query->where('customer.language IS NOT NULL');
+
+        return $query->executeQuery()->fetchFirstColumn();
     }
 
     private function fetchLocales(array $fetchedShopLocaleIds, MigrationContextInterface $migrationContext): array

--- a/src/Profile/Shopware/Gateway/Local/Reader/LanguageReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/LanguageReader.php
@@ -44,6 +44,7 @@ class LanguageReader extends AbstractReader implements ReaderInterface
             $this->fetchShopLocaleIds($migrationContext),
             $this->fetchCustomerLocaleIds($migrationContext)
         ));
+
         $locales = $this->fetchLocales($fetchedShopLocaleIds, $migrationContext);
 
         return $this->appendAssociatedData($locales, $migrationContext);

--- a/src/Profile/Shopware/Gateway/Local/Reader/LanguageReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/LanguageReader.php
@@ -79,6 +79,9 @@ class LanguageReader extends AbstractReader implements ReaderInterface
         return $query->fetchFirstColumn();
     }
 
+    /**
+     * @return list<mixed>
+     */
     private function fetchCustomerLocaleIds(MigrationContextInterface $migrationContext): array
     {
         $connection = $this->getConnection($migrationContext);

--- a/tests/Profile/Shopware/Gateway/Local/LanguageReaderTest.php
+++ b/tests/Profile/Shopware/Gateway/Local/LanguageReaderTest.php
@@ -60,6 +60,7 @@ class LanguageReaderTest extends TestCase
 
     protected function tearDown(): void
     {
+        // reset customer to the fixture default locale
         $this->dbConnection->executeStatement('UPDATE s_user SET language = :language WHERE id = :id', [
             'language' => 1,
             'id' => 1,

--- a/tests/Profile/Shopware/Gateway/Local/LanguageReaderTest.php
+++ b/tests/Profile/Shopware/Gateway/Local/LanguageReaderTest.php
@@ -50,6 +50,7 @@ class LanguageReaderTest extends TestCase
         );
 
         $this->migrationContext->setGateway(new DummyLocalGateway());
+
         $this->dbConnection = $connectionFactory->createDatabaseConnection($this->migrationContext);
         $this->dbConnection->executeStatement('UPDATE s_user SET language = :language WHERE id = :id', [
             'language' => 1,
@@ -63,6 +64,7 @@ class LanguageReaderTest extends TestCase
             'language' => 1,
             'id' => 1,
         ]);
+
         if ($this->customerLocaleInserted) {
             $this->dbConnection->executeStatement('DELETE FROM s_core_locales WHERE id = :id', ['id' => $this->customerLocaleId]);
         }
@@ -105,6 +107,7 @@ class LanguageReaderTest extends TestCase
                     'territory' => 'Egypt',
                 ]
             );
+
             $this->customerLocaleInserted = true;
         } else {
             $this->customerLocaleId = (int) $existingLocaleId;

--- a/tests/Profile/Shopware/Gateway/Local/LanguageReaderTest.php
+++ b/tests/Profile/Shopware/Gateway/Local/LanguageReaderTest.php
@@ -30,6 +30,8 @@ class LanguageReaderTest extends TestCase
 
     private int $customerLocaleId = 9999;
 
+    private bool $customerLocaleInserted = false;
+
     protected function setUp(): void
     {
         $this->connectionSetup();
@@ -49,6 +51,10 @@ class LanguageReaderTest extends TestCase
 
         $this->migrationContext->setGateway(new DummyLocalGateway());
         $this->dbConnection = $connectionFactory->createDatabaseConnection($this->migrationContext);
+        $this->dbConnection->executeStatement('UPDATE s_user SET language = :language WHERE id = :id', [
+            'language' => 1,
+            'id' => 1,
+        ]);
     }
 
     protected function tearDown(): void
@@ -57,7 +63,9 @@ class LanguageReaderTest extends TestCase
             'language' => 1,
             'id' => 1,
         ]);
-        $this->dbConnection->executeStatement('DELETE FROM s_core_locales WHERE id = :id', ['id' => $this->customerLocaleId]);
+        if ($this->customerLocaleInserted) {
+            $this->dbConnection->executeStatement('DELETE FROM s_core_locales WHERE id = :id', ['id' => $this->customerLocaleId]);
+        }
     }
 
     public function testRead(): void
@@ -82,15 +90,26 @@ class LanguageReaderTest extends TestCase
 
     public function testReadIncludesCustomerLocalesOutsideShopLocales(): void
     {
-        $this->dbConnection->executeStatement(
-            'INSERT INTO s_core_locales (id, locale, language, territory) VALUES (:id, :locale, :language, :territory)',
-            [
-                'id' => $this->customerLocaleId,
-                'locale' => 'ar_EG',
-                'language' => 'Arabic',
-                'territory' => 'Egypt',
-            ]
+        $existingLocaleId = $this->dbConnection->fetchOne(
+            'SELECT id FROM s_core_locales WHERE locale = :locale',
+            ['locale' => 'ar_EG']
         );
+
+        if ($existingLocaleId === false) {
+            $this->dbConnection->executeStatement(
+                'INSERT INTO s_core_locales (id, locale, language, territory) VALUES (:id, :locale, :language, :territory)',
+                [
+                    'id' => $this->customerLocaleId,
+                    'locale' => 'ar_EG',
+                    'language' => 'Arabic',
+                    'territory' => 'Egypt',
+                ]
+            );
+            $this->customerLocaleInserted = true;
+        } else {
+            $this->customerLocaleId = (int) $existingLocaleId;
+        }
+
         $this->dbConnection->executeStatement('UPDATE s_user SET language = :language WHERE id = :id', [
             'language' => $this->customerLocaleId,
             'id' => 1,
@@ -99,6 +118,6 @@ class LanguageReaderTest extends TestCase
         $data = $this->languageReader->read($this->migrationContext);
 
         static::assertCount(3, $data);
-        static::assertSame('ar-EG', $data[0]['locale']);
+        static::assertContains('ar-EG', \array_column($data, 'locale'));
     }
 }

--- a/tests/Profile/Shopware/Gateway/Local/LanguageReaderTest.php
+++ b/tests/Profile/Shopware/Gateway/Local/LanguageReaderTest.php
@@ -7,6 +7,7 @@
 
 namespace SwagMigrationAssistant\Test\Profile\Shopware\Gateway\Local;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use SwagMigrationAssistant\Migration\MigrationContext;
@@ -25,11 +26,16 @@ class LanguageReaderTest extends TestCase
 
     private MigrationContext $migrationContext;
 
+    private Connection $dbConnection;
+
+    private int $customerLocaleId = 9999;
+
     protected function setUp(): void
     {
         $this->connectionSetup();
 
-        $this->languageReader = new LanguageReader(new ConnectionFactory());
+        $connectionFactory = new ConnectionFactory();
+        $this->languageReader = new LanguageReader($connectionFactory);
 
         $this->migrationContext = new MigrationContext(
             $this->connection,
@@ -42,6 +48,16 @@ class LanguageReaderTest extends TestCase
         );
 
         $this->migrationContext->setGateway(new DummyLocalGateway());
+        $this->dbConnection = $connectionFactory->createDatabaseConnection($this->migrationContext);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dbConnection->executeStatement('UPDATE s_user SET language = :language WHERE id = :id', [
+            'language' => 1,
+            'id' => 1,
+        ]);
+        $this->dbConnection->executeStatement('DELETE FROM s_core_locales WHERE id = :id', ['id' => $this->customerLocaleId]);
     }
 
     public function testRead(): void
@@ -62,5 +78,27 @@ class LanguageReaderTest extends TestCase
         static::assertSame('de-DE', $data[1]['_locale']);
         static::assertSame('de_DE', $data[1]['translations'][0]['locale']);
         static::assertSame('en_GB', $data[1]['translations'][1]['locale']);
+    }
+
+    public function testReadIncludesCustomerLocalesOutsideShopLocales(): void
+    {
+        $this->dbConnection->executeStatement(
+            'INSERT INTO s_core_locales (id, locale, language, territory) VALUES (:id, :locale, :language, :territory)',
+            [
+                'id' => $this->customerLocaleId,
+                'locale' => 'ar_EG',
+                'language' => 'Arabic',
+                'territory' => 'Egypt',
+            ]
+        );
+        $this->dbConnection->executeStatement('UPDATE s_user SET language = :language WHERE id = :id', [
+            'language' => $this->customerLocaleId,
+            'id' => 1,
+        ]);
+
+        $data = $this->languageReader->read($this->migrationContext);
+
+        static::assertCount(3, $data);
+        static::assertSame('ar-EG', $data[0]['locale']);
     }
 }

--- a/tests/Profile/Shopware55/Converter/CustomerConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/CustomerConverterTest.php
@@ -372,4 +372,29 @@ class CustomerConverterTest extends TestCase
         static::assertSame('Shopware AG', $converted['company']);
         static::assertSame(CustomerEntity::ACCOUNT_TYPE_BUSINESS, $converted['accountType']);
     }
+
+    public function testConvertKeepsDefaultAddressesWhenAddressSalutationIsUnknown(): void
+    {
+        $customerData = require __DIR__ . '/../../../_fixtures/customer_data.php';
+        $customerData = $customerData[0];
+        $customerData['addresses'][0]['salutation'] = 'unknown-salutation';
+
+        $context = Context::createDefaultContext();
+        $convertResult = $this->customerConverter->convert(
+            $customerData,
+            $context,
+            $this->migrationContext
+        );
+
+        $converted = $convertResult->getConverted();
+        static::assertNotNull($converted);
+        static::assertCount(3, $converted['addresses']);
+        static::assertArrayNotHasKey('salutationId', $converted['addresses'][0]);
+        static::assertSame($converted['addresses'][0]['id'], $converted['defaultBillingAddressId']);
+        static::assertSame($converted['addresses'][1]['id'], $converted['defaultShippingAddressId']);
+
+        $logs = $this->loggingService->getLoggingArray();
+        static::assertCount(1, $logs);
+        static::assertSame(ConvertEntityUnknownLog::getCode(), $logs[0]['code']);
+    }
 }

--- a/tests/Profile/Shopware55/Converter/CustomerConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/CustomerConverterTest.php
@@ -397,4 +397,49 @@ class CustomerConverterTest extends TestCase
         static::assertCount(1, $logs);
         static::assertSame(ConvertEntityUnknownLog::getCode(), $logs[0]['code']);
     }
+
+    public function testConvertUsesLanguageMappingWhenLanguageDoesNotExistYet(): void
+    {
+        $customerData = require __DIR__ . '/../../../_fixtures/customer_data.php';
+        $customerData = $customerData[0];
+        $customerData['customerlanguage']['locale'] = 'ar-EG';
+
+        $languageId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+        $this->mappingService->getOrCreateMapping(
+            $this->connectionId,
+            DefaultEntities::LANGUAGE,
+            'ar-EG',
+            $context,
+            null,
+            [],
+            $languageId
+        );
+
+        $languageLookup = $this->createMock(LanguageLookup::class);
+        $languageLookup->expects($this->never())->method('get');
+
+        $validator = static::getContainer()->get('validator');
+        $salesChannelRepo = static::getContainer()->get('sales_channel.repository');
+
+        $customerConverter = new Shopware55CustomerConverter(
+            $this->mappingService,
+            $this->loggingService,
+            $validator,
+            $salesChannelRepo,
+            static::getContainer()->get(CountryLookup::class),
+            $languageLookup,
+            static::getContainer()->get(CountryStateLookup::class),
+        );
+
+        $convertResult = $customerConverter->convert(
+            $customerData,
+            $context,
+            $this->migrationContext
+        );
+
+        $converted = $convertResult->getConverted();
+        static::assertNotNull($converted);
+        static::assertSame($languageId, $converted['languageId']);
+    }
 }


### PR DESCRIPTION
resolves #SWAG-327674 support ticket

### Problem

Fixes a Shopware 5 customer migration issue where `languageId` could be missing even though the customer locale was already known in the same migration run.

`CustomerConverter` resolved the customer language only through `LanguageLookup`, which checks existing SW6 language entities. In affected runs, a language mapping for the locale already existed, but the target `language` entity had not been persisted yet. That left `languageId` unset.

### Changes

- add a shared Shopware converter helper that resolves a language by: existing language mapping for locale & fallback to `LanguageLookup`
- switch `CustomerConverter` to use this helper for `customerlanguage.locale`