### PR TITLE
fix: consider time zone during migration of orders

### DIFF
--- a/src/Profile/Shopware/Converter/OrderConverter.php
+++ b/src/Profile/Shopware/Converter/OrderConverter.php
@@ -55,6 +55,10 @@ abstract class OrderConverter extends ShopwareConverter
 
     private const SHIPPING_ADDRESS = 'shipping';
 
+    private const SOURCE_TIMEZONE_FIELD = '_timezone';
+
+    private const UTC_TIMEZONE = 'UTC';
+
     protected string $mainLocale;
 
     protected Context $context;
@@ -187,7 +191,7 @@ abstract class OrderConverter extends ShopwareConverter
         ];
         $converted['totalRounding'] = $converted['itemRounding'];
 
-        $this->convertValue($converted, 'orderDateTime', $data, 'ordertime', self::TYPE_DATETIME);
+        $this->convertOrderDateTime($converted, $data);
 
         if (isset($data['status'])) {
             $stateMapping = $this->mappingService->getMapping(
@@ -1001,6 +1005,56 @@ abstract class OrderConverter extends ShopwareConverter
         $this->mappingIds[] = $salutationMapping['id'];
 
         return $salutationMapping['entityId'];
+    }
+
+    /**
+     * @param array<string, mixed> $converted
+     * @param array<string, mixed> $data
+     */
+    private function convertOrderDateTime(array &$converted, array &$data): void
+    {
+        $sourceTimezone = $this->getSourceTimezone($data);
+
+        if ($sourceTimezone === null) {
+            $this->convertValue($converted, 'orderDateTime', $data, 'ordertime', self::TYPE_DATETIME);
+            unset($data[self::SOURCE_TIMEZONE_FIELD]);
+
+            return;
+        }
+
+        if (!isset($data['ordertime']) || !\is_string($data['ordertime']) || $data['ordertime'] === '') {
+            unset($data['ordertime'], $data[self::SOURCE_TIMEZONE_FIELD]);
+
+            return;
+        }
+
+        try {
+            $orderDateTime = new \DateTimeImmutable($data['ordertime'], new \DateTimeZone($sourceTimezone));
+            $converted['orderDateTime'] = $orderDateTime
+                ->setTimezone(new \DateTimeZone(self::UTC_TIMEZONE))
+                ->format(\DATE_ATOM);
+        } catch (\Throwable) {
+            $this->convertValue($converted, 'orderDateTime', $data, 'ordertime', self::TYPE_DATETIME);
+            unset($data[self::SOURCE_TIMEZONE_FIELD]);
+
+            return;
+        }
+
+        unset($data['ordertime'], $data[self::SOURCE_TIMEZONE_FIELD]);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function getSourceTimezone(array $data): ?string
+    {
+        $sourceTimezone = $data[self::SOURCE_TIMEZONE_FIELD] ?? null;
+
+        if (!\is_string($sourceTimezone) || $sourceTimezone === '') {
+            return null;
+        }
+
+        return $sourceTimezone;
     }
 
     /**

--- a/src/Profile/Shopware/Gateway/Local/Reader/AbstractReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/AbstractReader.php
@@ -156,6 +156,32 @@ abstract class AbstractReader implements ResetInterface
         return $result ?: '';
     }
 
+    final protected function getDatabaseTimezone(MigrationContextInterface $migrationContext): ?string
+    {
+        try {
+            $timezone = $this->getConnection($migrationContext)->executeQuery(
+                <<<'SQL'
+                    SELECT timeZones.timeZone
+                    FROM (
+                        SELECT @@SESSION.time_zone AS timeZone
+                        UNION
+                        SELECT @@system_time_zone AS timeZone
+                    ) AS timeZones
+                    WHERE timeZone != 'SYSTEM'
+                    LIMIT 1
+                SQL
+            )->fetchOne();
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (!\is_string($timezone) || $timezone === '') {
+            return null;
+        }
+
+        return $timezone;
+    }
+
     /**
      * @param array<mixed> $data
      * @param array<mixed> $result

--- a/src/Profile/Shopware/Gateway/Local/Reader/OrderReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/OrderReader.php
@@ -151,12 +151,16 @@ class OrderReader extends AbstractReader implements ReaderInterface
         $orderEsd = $this->getOrderEsd($migrationContext);
         $orderDetails = $this->getOrderDetails($migrationContext);
         $orderDocuments = $this->getOrderDocuments($migrationContext);
+        $timezone = $this->getDatabaseTimezone($migrationContext);
 
         // represents the main language of the migrated shop
         $locale = $this->getDefaultShopLocale($migrationContext);
 
         foreach ($orders as &$order) {
             $order['_locale'] = \str_replace('_', '-', $locale);
+            if ($timezone !== null) {
+                $order['_timezone'] = $timezone;
+            }
             if (isset($orderDetails[$order['id']])) {
                 $order['details'] = $orderDetails[$order['id']];
                 if (isset($orderEsd[$order['id']])) {

--- a/tests/Profile/Shopware/Gateway/Local/OrderReaderTest.php
+++ b/tests/Profile/Shopware/Gateway/Local/OrderReaderTest.php
@@ -49,6 +49,8 @@ class OrderReaderTest extends TestCase
         static::assertSame('1', $data[0]['subshopID']);
         static::assertSame('2', $data[0]['customer']['id']);
         static::assertSame('de-DE', $data[0]['_locale']);
+        static::assertArrayHasKey('_timezone', $data[0]);
+        static::assertNotSame('', $data[0]['_timezone']);
 
         static::assertSame('57', $data[1]['id']);
         static::assertSame('20002', $data[1]['ordernumber']);
@@ -60,6 +62,8 @@ class OrderReaderTest extends TestCase
         static::assertSame('1', $data[1]['subshopID']);
         static::assertSame('1', $data[1]['customer']['id']);
         static::assertSame('de-DE', $data[1]['_locale']);
+        static::assertArrayHasKey('_timezone', $data[1]);
+        static::assertNotSame('', $data[1]['_timezone']);
 
         static::assertArrayHasKey('esd', $data[0]['details']['0']);
         static::assertArrayHasKey('downloadAvailablePaymentStatus', $data[0]['details']['0']['esd']);

--- a/tests/Profile/Shopware55/Converter/OrderConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/OrderConverterTest.php
@@ -349,6 +349,33 @@ class OrderConverterTest extends TestCase
         static::assertCount(0, $this->loggingService->getLoggingArray());
     }
 
+    public function testConvertNormalizesOrderDateTimeToUtc(): void
+    {
+        [$customerData, $orderData] = $this->getFixtureData();
+        $orderData[0]['_timezone'] = '+02:00';
+        $context = Context::createDefaultContext();
+
+        $this->customerConverter->convert(
+            $customerData[0],
+            $context,
+            $this->customerMigrationContext
+        );
+
+        $convertResult = $this->orderConverter->convert(
+            $orderData[0],
+            $context,
+            $this->migrationContext
+        );
+
+        $converted = $convertResult->getConverted();
+        static::assertIsArray($converted);
+        static::assertSame('2018-10-09T09:48:06+00:00', $converted['orderDateTime']);
+        static::assertSame($converted['orderDateTime'], $converted['deliveries'][0]['shippingDateEarliest']);
+        static::assertSame($converted['orderDateTime'], $converted['deliveries'][0]['shippingDateLatest']);
+
+        static::assertNull($convertResult->getUnmapped());
+    }
+
     public function testConvertTaxFreeOrder(): void
     {
         [$customerData, $orderData] = $this->getFixtureData();


### PR DESCRIPTION
closes: [#14184](https://github.com/shopware/shopware/issues/14186)

Gets time zone from source db and consider it during migration of orders