### PR TITLE
fix: keep order addresses during sw5 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed Shopware 6 sales channel migration so additional sales channels, such as Social Shopping, are now migrated correctly when their sales channel types already exist in the target shop before the migration starts
 - Sales channels with types that are not available in the target shop are now skipped instead of causing follow-up issues
+- Fixed Shopware 5 order migration so billing and shipping addresses are kept even when the salutation cannot be mapped during conversion
 
 # 17.0.0
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -2,6 +2,7 @@
 
 - #14435 - Die Migration von Shopware 6 Sales Channel wurde korrigiert, sodass zusätzliche Sales Channel wie Social Shopping jetzt korrekt migriert werden, wenn ihre Sales-Channel-Typen vor dem Start der Migration im Zielshop vorhanden sind.
 - #14435 - Sales Channel, deren Sales-Channel-Typen im Zielshop nicht verfügbar sind, werden nun übersprungen, anstatt Folgefehler in der Migration zu verursachen.
+- Die Migration von Shopware-5-Bestellungen wurde korrigiert, sodass Rechnungs- und Lieferadressen auch dann erhalten bleiben, wenn die Anrede während der Konvertierung nicht zugeordnet werden kann.
 
 # 17.0.0
 

--- a/src/Profile/Shopware/Converter/OrderConverter.php
+++ b/src/Profile/Shopware/Converter/OrderConverter.php
@@ -318,9 +318,14 @@ abstract class OrderConverter extends ShopwareConverter
         unset($data['attributes']);
 
         if (isset($data['locale'])) {
-            $languageMapping = $this->languageLookup->get($data['locale'], $this->context);
-            if ($languageMapping !== null) {
-                $converted['languageId'] = $languageMapping;
+            $languageId = $this->resolveLanguageId(
+                $data['locale'],
+                $this->languageLookup,
+                $this->context,
+            );
+
+            if ($languageId !== null) {
+                $converted['languageId'] = $languageId;
             }
         }
 
@@ -495,10 +500,9 @@ abstract class OrderConverter extends ShopwareConverter
         }
 
         $salutationUuid = $this->getSalutation($originalData['salutation']);
-        if ($salutationUuid === null) {
-            return [];
+        if ($salutationUuid !== null) {
+            $address['salutationId'] = $salutationUuid;
         }
-        $address['salutationId'] = $salutationUuid;
 
         $this->convertValue($address, 'firstName', $originalData, 'firstname');
         $this->convertValue($address, 'lastName', $originalData, 'lastname');

--- a/tests/Profile/Shopware55/Converter/OrderConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/OrderConverterTest.php
@@ -551,6 +551,71 @@ class OrderConverterTest extends TestCase
         static::assertCount(0, $this->loggingService->getLoggingArray());
     }
 
+    public function testConvertKeepsBillingAddressWhenSalutationIsUnknown(): void
+    {
+        [$customerData, $orderData] = $this->getFixtureData();
+        $orderData = $orderData[0];
+        $orderData['billingaddress']['salutation'] = 'unknown-salutation';
+        $context = Context::createDefaultContext();
+
+        $this->customerConverter->convert(
+            $customerData[0],
+            $context,
+            $this->customerMigrationContext
+        );
+
+        $convertResult = $this->orderConverter->convert(
+            $orderData,
+            $context,
+            $this->migrationContext
+        );
+
+        $converted = $convertResult->getConverted();
+
+        static::assertNotNull($converted);
+        static::assertArrayHasKey('billingAddressId', $converted);
+        static::assertArrayHasKey('addresses', $converted);
+        static::assertSame($converted['addresses'][0]['id'], $converted['billingAddressId']);
+        static::assertArrayNotHasKey('salutationId', $converted['addresses'][0]);
+
+        $logs = $this->loggingService->getLoggingArray();
+        static::assertCount(1, $logs);
+        static::assertSame(ConvertEntityUnknownLog::getCode(), $logs[0]['code']);
+    }
+
+    public function testConvertKeepsShippingAddressWhenSalutationIsUnknown(): void
+    {
+        [$customerData, $orderData] = $this->getFixtureData();
+        $orderData = $orderData[0];
+        $orderData['shippingaddress']['salutation'] = 'unknown-salutation';
+        $context = Context::createDefaultContext();
+
+        $this->customerConverter->convert(
+            $customerData[0],
+            $context,
+            $this->customerMigrationContext
+        );
+
+        $convertResult = $this->orderConverter->convert(
+            $orderData,
+            $context,
+            $this->migrationContext
+        );
+
+        $converted = $convertResult->getConverted();
+
+        static::assertNotNull($converted);
+        static::assertArrayHasKey('deliveries', $converted);
+        static::assertArrayHasKey('shippingOrderAddress', $converted['deliveries'][0]);
+        static::assertArrayNotHasKey('salutationId', $converted['deliveries'][0]['shippingOrderAddress']);
+        static::assertSame('Max', $converted['deliveries'][0]['shippingOrderAddress']['firstName']);
+        static::assertSame('Mustermann', $converted['deliveries'][0]['shippingOrderAddress']['lastName']);
+
+        $logs = $this->loggingService->getLoggingArray();
+        static::assertCount(1, $logs);
+        static::assertSame(ConvertEntityUnknownLog::getCode(), $logs[0]['code']);
+    }
+
     /**
      * @return list<list<string>>
      */
@@ -675,6 +740,58 @@ class OrderConverterTest extends TestCase
         static::assertArrayHasKey('id', $converted);
         static::assertCount(0, $this->loggingService->getLoggingArray());
         static::assertSame(DummyMappingService::DEFAULT_LANGUAGE_UUID, $converted['languageId']);
+    }
+
+    public function testConvertUsesLanguageMappingWhenLanguageDoesNotExistYet(): void
+    {
+        [$customerData, $orderData] = $this->getFixtureData();
+        $context = Context::createDefaultContext();
+        $languageId = Uuid::randomHex();
+
+        $languageLookup = $this->createMock(LanguageLookup::class);
+        $languageLookup->method('get')->with('ar-EG', $context)->willReturn(null);
+
+        $currencyLookup = $this->createMock(CurrencyLookup::class);
+        $currencyLookup->method('get')->willReturn('b7d2554b0ce847cd82f3ac9bd1c0dfca');
+
+        $orderConverter = new Shopware55OrderConverter(
+            $this->mappingService,
+            $this->loggingService,
+            new TaxCalculator(),
+            static::getContainer()->get('sales_channel.repository'),
+            static::getContainer()->get(CountryLookup::class),
+            $currencyLookup,
+            $languageLookup,
+            $this->createMock(CountryStateLookup::class)
+        );
+
+        $this->mappingService->getOrCreateMapping(
+            $this->migrationContext->getConnection()->getId(),
+            DefaultEntities::LANGUAGE,
+            'ar-EG',
+            $context,
+            null,
+            [],
+            $languageId
+        );
+
+        $this->customerConverter->convert(
+            $customerData[0],
+            $context,
+            $this->customerMigrationContext
+        );
+
+        $orderData[0]['locale'] = 'ar-EG';
+        $convertResult = $orderConverter->convert(
+            $orderData[0],
+            $context,
+            $this->migrationContext
+        );
+
+        $converted = $convertResult->getConverted();
+
+        static::assertNotNull($converted);
+        static::assertSame($languageId, $converted['languageId']);
     }
 
     public function testConvertWithDuplicatedEMails(): void


### PR DESCRIPTION
#SWAG-327674

Fixes a Shopware 5 order migration issue where billing and shipping order addresses could be dropped during conversion even though the source address data was present. This caused follow up validation errors like missing `billingAddressId` and empty `shippingOrderAddress` fields. The change keeps the order address data intact instead of losing the whole address during conversion, and adds regression tests for billing and shipping address handling.