### PR TITLE
ci: fix release branch creation

### DIFF
--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -7,19 +7,24 @@ jobs:
         permissions:
             contents: write
         steps:
+            - name: Checkout
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 0
+
+            - name: Get version
+              run: echo "VERSION=$(jq -r '.version' composer.json)" >> "$GITHUB_ENV"
+
+            - name: Create release branch (from source state, before store-release strips dev files)
+              run: |
+                  git checkout -b "release/${VERSION}"
+                  git push origin "release/${VERSION}"
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
             - uses: shopware/github-actions/store-release@main
               with:
                   extensionName: ${{ github.event.repository.name }}
                   clientId: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_ID }}
                   clientSecret: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET }}
                   ghToken: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Get version
-              run: echo "VERSION=$(shopware-cli extension get-version .)" >> $GITHUB_ENV
-
-            - name: Create release branch
-              run: |
-                  git checkout -b release/${VERSION}
-                  git push origin release/${VERSION}
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Missed that when creating the `release/***` branch as the last step, the `tests` dir is missing because of the prior build step. So exactly what we wanted to prevent 😄.

Moved the branch creation up before the actual build, so the branch state is unchanged from trunk.