### PR TITLE
fix: missing status in converted newsletter recipient

### DIFF
--- a/src/Profile/Shopware/Converter/NewsletterRecipientConverter.php
+++ b/src/Profile/Shopware/Converter/NewsletterRecipientConverter.php
@@ -117,6 +117,7 @@ abstract class NewsletterRecipientConverter extends ShopwareConverter
             return new ConvertStruct(null, $oldData);
         }
 
+        $converted["status"] = $status;
         $converted['languageId'] = $this->languageLookup->get($this->locale, $context);
         $converted['salesChannelId'] = $this->getSalesChannel($data);
 

--- a/src/Profile/Shopware/Converter/NewsletterRecipientConverter.php
+++ b/src/Profile/Shopware/Converter/NewsletterRecipientConverter.php
@@ -117,7 +117,7 @@ abstract class NewsletterRecipientConverter extends ShopwareConverter
             return new ConvertStruct(null, $oldData);
         }
 
-        $converted["status"] = $status;
+        $converted['status'] = $status;
         $converted['languageId'] = $this->languageLookup->get($this->locale, $context);
         $converted['salesChannelId'] = $this->getSalesChannel($data);
 

--- a/tests/Profile/Shopware55/Converter/NewsletterRecipientConverterTest.php
+++ b/tests/Profile/Shopware55/Converter/NewsletterRecipientConverterTest.php
@@ -133,5 +133,6 @@ class NewsletterRecipientConverterTest extends TestCase
         static::assertArrayHasKey('email', $converted);
         static::assertArrayHasKey('salutationId', $converted);
         static::assertArrayHasKey('languageId', $converted);
+        static::assertArrayHasKey('status', $converted);
     }
 }


### PR DESCRIPTION
Status was missing in the converted object after the last commit due to it never being set.

The status was only stored in a variable and not assigned in the converted object. This caused a warning due to a missing field "status" in the newsletter recipients migration flow.
