### PR TITLE
test: use createMock instead of getMockBuilder constructor bypass

### DIFF
--- a/tests/Profile/Shopware/Gateway/ApiReaderTest.php
+++ b/tests/Profile/Shopware/Gateway/ApiReaderTest.php
@@ -56,7 +56,7 @@ class ApiReaderTest extends TestCase
             null,
             new ProductDataSet(),
         );
-        $mock = $this->getMockBuilder(ConnectionFactory::class)->getMock();
+        $mock = $this->createMock(ConnectionFactory::class);
         $mock->expects($this->once())
             ->method('createApiClient')
             ->with($migrationContext)
@@ -88,7 +88,7 @@ class ApiReaderTest extends TestCase
             null,
             new ProductDataSet(),
         );
-        $mock = $this->getMockBuilder(ConnectionFactory::class)->getMock();
+        $mock = $this->createMock(ConnectionFactory::class);
         $mock->expects($this->once())
             ->method('createApiClient')
             ->with($migrationContext)


### PR DESCRIPTION
follow-up on shopware/shopware#17246

see failing nightly: https://github.com/shopware/SwagMigrationAssistant/actions/runs/27318522352/job/80704297123