### PR TITLE
chore: adapt EntitySearchResult usage for 6.8 deprecation

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -52,6 +52,9 @@ parameters:
         - message: '#Call to deprecated method listTableIndexes\(\) of class Doctrine\\DBAL\\Schema\\AbstractSchemaManager#'
         - message: '#Call to deprecated method getName\(\) of class Doctrine\\DBAL\\Schema\\AbstractAsset#'
         - message: '#Call to deprecated method listTableForeignKeys\(\) of class Doctrine\\DBAL\\Schema\\AbstractSchemaManager#'
+        - message: '#Call to method .* of deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult#'
+        - message: '#Instantiation of deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult#'
+        - message: '#has typehint with deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult#'
 
         # TODO: The MainOrContainer type cannot fully express its state after nested array mutations
         - identifier: parameterByRef.type
@@ -60,6 +63,7 @@ parameters:
         # This rule's exemption only accepts @see targets in the \Tests\Integration\ namespace,
         # which plugins (namespace SwagMigrationAssistant\Test\) cannot satisfy.
         - identifier: shopware.codeCoverageIgnoreOnLogic
+          reportUnmatched: false
 
 rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Deprecation\DeprecatedMethodsThrowDeprecationRule

--- a/src/DataProvider/Provider/Data/DocumentInheritanceProvider.php
+++ b/src/DataProvider/Provider/Data/DocumentInheritanceProvider.php
@@ -45,7 +45,7 @@ class DocumentInheritanceProvider extends AbstractProvider
 
         $result = [];
         /** @var DocumentEntity $document */
-        foreach ($searchResult->getElements() as $document) {
+        foreach ($searchResult->getEntities()->getElements() as $document) {
             $result[] = [
                 'id' => $document->getId(),
                 'referencedDocumentId' => $document->getReferencedDocumentId(),

--- a/src/Migration/Mapping/Lookup/GlobalDocumentBaseConfigLookup.php
+++ b/src/Migration/Mapping/Lookup/GlobalDocumentBaseConfigLookup.php
@@ -67,7 +67,7 @@ class GlobalDocumentBaseConfigLookup implements ResetInterface
 
         $criteria = new Criteria([$baseConfigId]);
 
-        $baseConfig = $this->documentBaseConfigRepository->search($criteria, $context)->first();
+        $baseConfig = $this->documentBaseConfigRepository->search($criteria, $context)->getEntities()->first();
 
         $config = $baseConfig?->getConfig();
         $this->configCache[$baseConfigId] = $config;

--- a/src/Migration/Mapping/Lookup/LanguageLookup.php
+++ b/src/Migration/Mapping/Lookup/LanguageLookup.php
@@ -76,7 +76,7 @@ class LanguageLookup implements ResetInterface
         $criteria = new Criteria([$languageUuid]);
         $criteria->addAssociation('locale');
 
-        $language = $this->languageRepository->search($criteria, $context)->first();
+        $language = $this->languageRepository->search($criteria, $context)->getEntities()->first();
 
         if (!$language instanceof LanguageEntity) {
             $this->defaultLanguageCache[$languageUuid] = null;

--- a/src/Migration/Mapping/Lookup/ProductSortingLookup.php
+++ b/src/Migration/Mapping/Lookup/ProductSortingLookup.php
@@ -49,7 +49,7 @@ class ProductSortingLookup implements ResetInterface
         $criteria->addFilter(new EqualsFilter('key', $key));
         $criteria->setLimit(1);
 
-        $productSorting = $this->productSortingRepository->search($criteria, $context)->first();
+        $productSorting = $this->productSortingRepository->search($criteria, $context)->getEntities()->first();
 
         $productSortingUuid = null;
         $isLocked = false;

--- a/src/Migration/Mapping/MappingService.php
+++ b/src/Migration/Mapping/MappingService.php
@@ -221,7 +221,7 @@ class MappingService implements MappingServiceInterface, ResetInterface
 
         $result = $this->migrationMappingRepo->search(new Criteria($mappingIds), $context);
 
-        if ($result->count() > 0) {
+        if ($result->getEntities()->count() > 0) {
             $elements = $result->getEntities()->getElements();
             foreach ($elements as $mapping) {
                 $entityName = $mapping->getEntity();

--- a/src/Migration/MigrationContextFactory.php
+++ b/src/Migration/MigrationContextFactory.php
@@ -92,7 +92,7 @@ readonly class MigrationContextFactory implements MigrationContextFactoryInterfa
 
     public function createBySelectedConnection(Context $context): MigrationContextInterface
     {
-        $settings = $this->generalSettingRepository->search(new Criteria(), $context)->first();
+        $settings = $this->generalSettingRepository->search(new Criteria(), $context)->getEntities()->first();
 
         if (!$settings instanceof GeneralSettingEntity) {
             throw MigrationException::entityNotExists(GeneralSettingEntity::class, 'Default');

--- a/src/Migration/Run/RunService.php
+++ b/src/Migration/Run/RunService.php
@@ -598,7 +598,7 @@ class RunService implements RunServiceInterface
             return [];
         }
 
-        return $this->salesChannelRepository->search(new Criteria($salesChannelUuids), $context)->getIds();
+        return $this->salesChannelRepository->search(new Criteria($salesChannelUuids), $context)->getEntities()->getIds();
     }
 
     private function getDefaultTheme(Context $context): ?string
@@ -606,7 +606,7 @@ class RunService implements RunServiceInterface
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('technicalName', 'Storefront'));
 
-        $ids = $this->themeRepository->search($criteria, $context)->getIds();
+        $ids = $this->themeRepository->search($criteria, $context)->getEntities()->getIds();
 
         if ($ids === []) {
             return null;

--- a/src/Migration/Service/MigrationDataWriter.php
+++ b/src/Migration/Service/MigrationDataWriter.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
@@ -143,7 +142,7 @@ class MigrationDataWriter implements MigrationDataWriterInterface
                 $updateWrittenData,
                 $migrationContext,
                 $context,
-                $migrationData
+                $migrationData->getEntities()
             );
         } catch (\Throwable) {
             // Worst case: something unknown goes wrong (most likely some foreign key constraint that fails)
@@ -171,7 +170,6 @@ class MigrationDataWriter implements MigrationDataWriterInterface
     /**
      * @param array<string, mixed> $converted
      * @param array<string, mixed> $updateWrittenData
-     * @param EntitySearchResult<SwagMigrationDataCollection> $migrationData
      */
     private function handleWriteException(
         WriteException $exception,
@@ -180,7 +178,7 @@ class MigrationDataWriter implements MigrationDataWriterInterface
         array &$updateWrittenData,
         MigrationContextInterface $migrationContext,
         Context $context,
-        EntitySearchResult $migrationData,
+        SwagMigrationDataCollection $migrationData,
     ): void {
         $writeErrors = $this->extractWriteErrorsWithIndex($exception);
         $currentWriter = $this->writerRegistry->getWriter($entityName);

--- a/src/Profile/Shopware/Converter/SalesChannelConverter.php
+++ b/src/Profile/Shopware/Converter/SalesChannelConverter.php
@@ -342,7 +342,7 @@ abstract class SalesChannelConverter extends ShopwareConverter
         $result = $this->languagePackRepo->search($criteria, Context::createDefaultContext());
 
         if ($result->getTotal() !== 0) {
-            foreach ($result->getElements() as $packLanguage) {
+            foreach ($result->getEntities()->getElements() as $packLanguage) {
                 $packLanguageId = $packLanguage->getLanguageId();
 
                 foreach ($converted['languages'] as &$language) {

--- a/src/Profile/Shopware/Premapping/OrderDeliveryStateReader.php
+++ b/src/Profile/Shopware/Premapping/OrderDeliveryStateReader.php
@@ -129,7 +129,7 @@ class OrderDeliveryStateReader extends AbstractPremappingReader
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('technicalName', OrderDeliveryStates::STATE_MACHINE));
 
-        $stateMachine = $this->stateMachineRepo->search($criteria, $context)->first();
+        $stateMachine = $this->stateMachineRepo->search($criteria, $context)->getEntities()->first();
 
         if (!$stateMachine instanceof StateMachineEntity) {
             return [];

--- a/src/Profile/Shopware/Premapping/OrderStateReader.php
+++ b/src/Profile/Shopware/Premapping/OrderStateReader.php
@@ -129,7 +129,7 @@ class OrderStateReader extends AbstractPremappingReader
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('technicalName', OrderStates::STATE_MACHINE));
 
-        $stateMachine = $this->stateMachineRepo->search($criteria, $context)->first();
+        $stateMachine = $this->stateMachineRepo->search($criteria, $context)->getEntities()->first();
 
         if (!$stateMachine instanceof StateMachineEntity) {
             return [];

--- a/src/Profile/Shopware/Premapping/TransactionStateReader.php
+++ b/src/Profile/Shopware/Premapping/TransactionStateReader.php
@@ -127,7 +127,7 @@ class TransactionStateReader extends AbstractPremappingReader
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('technicalName', OrderTransactionStates::STATE_MACHINE));
 
-        $stateMachine = $this->stateMachineRepo->search($criteria, $context)->first();
+        $stateMachine = $this->stateMachineRepo->search($criteria, $context)->getEntities()->first();
 
         if (!$stateMachine instanceof StateMachineEntity) {
             return [];

--- a/tests/Migration/Services/MigrationDataProcessingTest.php
+++ b/tests/Migration/Services/MigrationDataProcessingTest.php
@@ -374,7 +374,7 @@ class MigrationDataProcessingTest extends TestCase
                 $context
             );
         });
-        $connection = $this->connectionRepo->search(new Criteria([$this->connectionId]), $this->context)->first();
+        $connection = $this->connectionRepo->search(new Criteria([$this->connectionId]), $this->context)->getEntities()->first();
 
         static::assertInstanceOf(SwagMigrationConnectionEntity::class, $connection);
 

--- a/tests/Migration/Services/MigrationDataWriterTest.php
+++ b/tests/Migration/Services/MigrationDataWriterTest.php
@@ -25,7 +25,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
@@ -352,15 +351,6 @@ class MigrationDataWriterTest extends TestCase
         $entity->setRaw(['name' => 'myProduct']);
         $collection = new SwagMigrationDataCollection([$entity]);
 
-        $searchResult = new EntitySearchResult(
-            SwagMigrationDataEntity::class,
-            1,
-            $collection,
-            null,
-            new Criteria(),
-            $this->context,
-        );
-
         $updateWrittenData = [];
         $this->invokeMethod($this->migrationDataWriter, 'handleWriteException', [
             new WriteException(),
@@ -373,7 +363,7 @@ class MigrationDataWriterTest extends TestCase
             &$updateWrittenData,
             $migrationContext,
             $this->context,
-            $searchResult,
+            $collection,
         ]);
 
         $loggingServiceProperty = (new \ReflectionClass(MigrationDataWriter::class))->getProperty('loggingService');
@@ -744,7 +734,7 @@ class MigrationDataWriterTest extends TestCase
                 $context
             );
         });
-        $connection = $this->connectionRepo->search(new Criteria([$this->connectionId]), $this->context)->first();
+        $connection = $this->connectionRepo->search(new Criteria([$this->connectionId]), $this->context)->getEntities()->first();
 
         static::assertInstanceOf(SwagMigrationConnectionEntity::class, $connection);
 

--- a/tests/integration/Migration/ErrorResolution/MigrationErrorResolutionServiceTest.php
+++ b/tests/integration/Migration/ErrorResolution/MigrationErrorResolutionServiceTest.php
@@ -243,7 +243,7 @@ class MigrationErrorResolutionServiceTest extends TestCase
 
             $runRepository->create($runData, $context);
             $criteria = new Criteria([$runId]);
-            $swagMigrationRun = $runRepository->search($criteria, $context)->first();
+            $swagMigrationRun = $runRepository->search($criteria, $context)->getEntities()->first();
         });
 
         static::assertInstanceOf(SwagMigrationRunEntity::class, $swagMigrationRun);
@@ -275,7 +275,7 @@ class MigrationErrorResolutionServiceTest extends TestCase
             );
 
             $criteria = new Criteria([$connectionId]);
-            $connection = $connectionRepository->search($criteria, $context)->first();
+            $connection = $connectionRepository->search($criteria, $context)->getEntities()->first();
         });
 
         static::assertInstanceOf(SwagMigrationConnectionEntity::class, $connection);


### PR DESCRIPTION
see failing nightly: https://github.com/shopware/SwagMigrationAssistant/actions/runs/28910867430

follow-up to shopware/shopware#17101