### PR TITLE
ci: add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
       directory: '/'
       schedule:
           interval: 'weekly'
+      cooldown:
+          default-days: 7
+          semver-major-days: 30
+          semver-minor-days: 14
+          semver-patch-days: 7
       reviewers:
           - 'shopware/product-cc-after-sales'
       commit-message:


### PR DESCRIPTION
add dependabot cooldown to reduce risk of supply chain attack

- major: 30 days
- minor: 14 days
- patch: 7 days