### PR TITLE
ci: verify extension against lowest dependencies

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -40,7 +40,7 @@ jobs:
               run: composer config policy.advisories.block false
 
             - name: Run verifier
-              uses: shopware/github-actions/extension-verifier@extension-verifier-exclude
+              uses: shopware/github-actions/extension-verifier@main
               with:
                   action: check
                   check-against: lowest

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -44,3 +44,4 @@ jobs:
               with:
                   action: check
                   check-against: lowest
+                  exclude: stylelint

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -40,7 +40,7 @@ jobs:
               run: composer config policy.advisories.block false
 
             - name: Run verifier
-              uses: shopware/github-actions/extension-verifier@main
+              uses: shopware/github-actions/extension-verifier@extension-verifier-exclude
               with:
                   action: check
                   check-against: lowest

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -25,3 +25,22 @@ jobs:
         uses: ./.github/workflows/action-phpstan.yml
         with:
             extension_name: ${{ github.event.repository.name }}
+
+    extension_verifier:
+        name: Extension Verifier (lowest)
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout SwagMigrationAssistant
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+            - name: Remove PHPStan config
+              run: rm phpstan.neon.dist
+
+            - name: Allow composer to resolve advisory-affected releases
+              run: composer config policy.advisories.block false
+
+            - name: Run verifier
+              uses: shopware/github-actions/extension-verifier@main
+              with:
+                  action: check
+                  check-against: lowest

--- a/.shopware-extension.yml
+++ b/.shopware-extension.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://shopware.github.io/shopware-cli/shopware-extension-schema.json
+compatibility_date: '2026-08-14'
+
+validation:
+    ignore:
+        # The verifier's PHPStan cannot see functions defined in vendor PSR-4 files, these resolve at runtime.
+        - message: 'Function service not found'
+        - message: 'Function tagged_iterator not found'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - #17832 - Fixed attribute migration so custom fields with an empty label no longer abort the run. The reader now keeps the `column_name` in the attribute configuration.
 - #12748 - Fixed order migration so `product.sales` is recalculated from persisted order line items after migrated orders are written. Cancelled orders are excluded from the sales calculation.
+- Fixed attribute migration on installations that resolve Doctrine DBAL 4.2, where reading attributes through the Shopware local gateway aborted the run.
 
 # 18.0.0
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -2,6 +2,7 @@
 
 - #17832 - Die Attribut-Migration wurde korrigiert, sodass Zusatzfelder mit leerem Label die Migration nicht mehr abbrechen. Der Reader behält nun den `column_name` in der Attributkonfiguration.
 - #12748 - Die Migration von Bestellungen wurde korrigiert, sodass `product.sales` nach dem Schreiben migrierter Bestellungen anhand der persistierten Bestellpositionen neu berechnet wird. Stornierte Bestellungen werden dabei nicht berücksichtigt.
+- Die Attribut-Migration wurde für Installationen korrigiert, die Doctrine DBAL 4.2 auflösen. Dort brach das Lesen der Attribute über das lokale Shopware-Gateway die Migration ab.
 
 # 18.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
     "require": {
         "shopware/core": "~6.7"
     },
+    "suggest": {
+        "shopware/storefront": "Required for migrating themes and their sales channel assignments"
+    },
     "extra": {
         "shopware-plugin-class": "SwagMigrationAssistant\\SwagMigrationAssistant",
         "plugin-icon": "src/Resources/config/plugin.png",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -48,6 +48,9 @@ parameters:
         - message: '#Call to deprecated method listTableForeignKeys\(\) of class Doctrine\\DBAL\\Schema\\AbstractSchemaManager#'
           paths:
               - src/Profile/Shopware/Gateway/Local/Reader/AttributeReader.php
+        - message: '#Call to deprecated method getLocalColumns\(\) of class Doctrine\\DBAL\\Schema\\ForeignKeyConstraint#'
+          paths:
+              - src/Profile/Shopware/Gateway/Local/Reader/AttributeReader.php
 
         # TODO: The MainOrContainer type cannot fully express its state after nested array mutations
         - identifier: parameterByRef.type

--- a/src/Profile/Shopware/Gateway/Local/Reader/AttributeReader.php
+++ b/src/Profile/Shopware/Gateway/Local/Reader/AttributeReader.php
@@ -9,7 +9,6 @@ namespace SwagMigrationAssistant\Profile\Shopware\Gateway\Local\Reader;
 
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\AsciiStringType;
 use Doctrine\DBAL\Types\BigIntType;
 use Doctrine\DBAL\Types\BinaryType;
@@ -192,7 +191,8 @@ SQL;
         $fks = [];
 
         foreach ($foreignKeys as $foreignKey) {
-            $fks[] = array_map(static fn (UnqualifiedName $name) => $name->toString(), $foreignKey->getReferencingColumnNames());
+            // getLocalColumns() is deprecated, but getReferencingColumnNames() needs DBAL 4.3+ (Shopware 6.7.0/6.7.1 can lock DBAL 4.2)
+            $fks[] = $foreignKey->getLocalColumns();
         }
 
         if ($fks !== []) {


### PR DESCRIPTION
follow-up to shopware/SwagMigrationMagento#62 

- `AttributeReader::cleanupColumns()` used `getReferencingColumnNames()` and `UnqualifiedName` (DBAL 4.3+) since #67, so attribute reads through the Shopware local gateway failed on installs whose lockfiles contain an older DBAL
- the new `Extension Verifier (lowest)` job uses `shopware-cli` via [`shopware/github-actions/extension-verifier`](https://github.com/shopware/github-actions/tree/main/extension-verifier) to [validate](https://developer.shopware.com/docs/products/tools/cli/validation.html) the plugin against its lowest resolvable dependencies to catch issues like this in CI in the future
- `shopware/storefront` added to `suggest`, the verifier installs suggested packages and needs them to resolve the theme classes `RunService` pulls in
- the two Symfony DI configurator findings ignored in `.shopware-extension.yml` instead of fixed in code, the only in-code fix would be moving `src/DependencyInjection/*.php` to `src/Resources/config/` which felt too heavy here

example output from the [first run of the job](https://github.com/shopware/SwagMigrationAssistant/actions/runs/31796290825/job/94754024779?pr=218):

```text
phpstan.neon
  0  error    [phpstan/error]  Internal error: Class Doctrine\DBAL\Schema\Name\UnqualifiedName was not found while trying to analyse it - discovering symbols is probably not configured properly. while analysing file /tmp/analyse-extension-1320630473/src/Profile/Shopware/Gateway/Local/Reader/AttributeReader.php

✖ 10 problems (5 errors, 5 warnings)
```