### PR TITLE
test: scope visual snapshots

### DIFF
--- a/tests/acceptance/fixtures/TestHelpers.ts
+++ b/tests/acceptance/fixtures/TestHelpers.ts
@@ -5,7 +5,6 @@ export const LOADING_TIMEOUT = 30_000; // 30s
 
 export const VIEWPORT = {
     DEFAULT: { width: 1440, height: 1080 },
-    LARGE: { width: 1440, height: 1440 },
 };
 
 export const loaderSelectors = [
@@ -26,11 +25,50 @@ export const dynamicElementSelectors = [
     ...loaderSelectors,
 ] as const;
 
+export const defaultIgnoredSelectors = [
+    '.sw-page__search-bar',
+    '.sw-page__top-bar-actions',
+] as const;
+
 export function getMask(page: Page, additional: string[] = []): Locator[] {
     return [
+        ...defaultIgnoredSelectors,
         ...dynamicElementSelectors,
         ...additional,
     ].map((selector) => page.locator(selector));
+}
+
+export async function expectSnapshot(
+    page: Page,
+    name: string,
+    options: { mask?: Locator[]; target?: Locator; clip?: boolean } = {},
+): Promise<void> {
+    let target = options.target;
+
+    if (!target) {
+        const modalDialog = page.locator('.sw-modal__dialog').last();
+        const modalIsOpen = (await modalDialog.count()) > 0 && (await modalDialog.isVisible());
+
+        target = modalIsOpen ? modalDialog : page.locator('.sw-page');
+    }
+
+    const mask = options.mask ?? getMask(page);
+
+    // A target that never settles fails element stability check.
+    // Skips per element wait while still framing only the target.
+    if (options.clip) {
+        await target.waitFor({ state: 'visible' });
+        const clip = await target.boundingBox();
+
+        await expect.soft(page).toHaveScreenshot(
+            name,
+            clip ? { mask, clip } : { mask }
+        );
+
+        return;
+    }
+
+    await expect.soft(target).toHaveScreenshot(name, { mask });
 }
 
 export async function waitForLoaders(page: Page, timeout = LOADING_TIMEOUT): Promise<void> {
@@ -45,21 +83,4 @@ export async function waitForLoaders(page: Page, timeout = LOADING_TIMEOUT): Pro
         });
 
     await expect(loader).toHaveCount(0, { timeout });
-}
-
-export async function withLargerViewport(
-    page: Page,
-    viewport: { width: number; height: number } = VIEWPORT.DEFAULT,
-): Promise<() => Promise<void>> {
-    const height = Math.max(viewport.height, VIEWPORT.LARGE.height);
-    const width = Math.max(viewport.width, VIEWPORT.LARGE.width);
-
-    const original = page.viewportSize();
-    await page.setViewportSize({ width, height });
-
-    return async () => {
-        if (original) {
-            await page.setViewportSize(original);
-        }
-    };
 }

--- a/tests/acceptance/tests/BasicVisualTest.spec.ts
+++ b/tests/acceptance/tests/BasicVisualTest.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@fixtures/AcceptanceTest';
-import { getMask, waitForLoaders } from '@fixtures/TestHelpers';
+import { expectSnapshot, waitForLoaders } from '@fixtures/TestHelpers';
 
 test.describe('Visual Regression Tests @visual', () => {
     test.describe.configure({
@@ -8,7 +8,6 @@ test.describe('Visual Regression Tests @visual', () => {
 
     test('Main page (no connection)', async ({ ShopAdmin }) => {
         const page = ShopAdmin.page;
-        const mask = getMask(page);
 
         await page.goto('/admin');
         await waitForLoaders(page);
@@ -16,17 +15,16 @@ test.describe('Visual Regression Tests @visual', () => {
         await page.getByRole('button', { name: 'Open Migration Assistant' }).click();
         await waitForLoaders(page);
 
-        await expect.soft(page).toHaveScreenshot('main-page-general-no-connection.png', { mask });
+        await expectSnapshot(page, 'main-page-general-no-connection.png');
 
         await page.getByTitle('Data selection').click();
         await waitForLoaders(page);
 
-        await expect.soft(page).toHaveScreenshot('main-page-data-selection-empty.png', { mask });
+        await expectSnapshot(page, 'main-page-data-selection-empty.png');
     });
 
     test('Main page (with connection)', async ({ ShopAdmin, MigrationConnection: _ }) => {
         const page = ShopAdmin.page;
-        const mask = getMask(page);
 
         await page.goto('/admin');
         await waitForLoaders(page);
@@ -34,17 +32,16 @@ test.describe('Visual Regression Tests @visual', () => {
         await page.getByRole('button', { name: 'Open Migration Assistant' }).click();
         await waitForLoaders(page);
 
-        await expect.soft(page).toHaveScreenshot('main-page-general-with-connection.png', { mask });
+        await expectSnapshot(page, 'main-page-general-with-connection.png');
 
         await page.getByTitle('Data selection').click();
         await waitForLoaders(page);
 
-        await expect.soft(page).toHaveScreenshot('main-page-data-selection.png', { mask });
+        await expectSnapshot(page, 'main-page-data-selection.png');
     });
 
     test('Connection wizard (local, happy path)', async ({ ShopAdmin, DatabaseCredentials }) => {
         const page = ShopAdmin.page;
-        const mask = getMask(page);
 
         await page.goto('/admin');
         await waitForLoaders(page);
@@ -55,17 +52,17 @@ test.describe('Visual Regression Tests @visual', () => {
         await page.getByRole('button', { name: 'Create initial connection' }).click();
         await waitForLoaders(page);
 
-        await expect.soft(page).toHaveScreenshot('connection-wizard-introduction.png', { mask });
+        await expectSnapshot(page, 'connection-wizard-introduction.png');
 
         await page.getByRole('button', { name: 'Start' }).click();
         await waitForLoaders(page);
 
-        await expect.soft(page).toHaveScreenshot('connection-wizard-profiles.png', { mask });
+        await expectSnapshot(page, 'connection-wizard-profiles.png');
 
         await page.getByRole('button', { name: 'Continue' }).click();
         await waitForLoaders(page);
 
-        await expect.soft(page).toHaveScreenshot('connection-wizard-create.png', { mask });
+        await expectSnapshot(page, 'connection-wizard-create.png');
 
         await page.getByPlaceholder('Enter name').fill('shopware55local');
 
@@ -78,7 +75,7 @@ test.describe('Visual Regression Tests @visual', () => {
         // lose focus of host input
         await page.locator('.sw-modal__title').click();
 
-        await expect.soft(page).toHaveScreenshot('connection-wizard-establish-local.png', { mask });
+        await expectSnapshot(page, 'connection-wizard-establish-local.png');
 
         await page.getByPlaceholder('Enter host').fill(DatabaseCredentials.host);
         await page.getByLabel('Port').fill(DatabaseCredentials.port);
@@ -97,7 +94,7 @@ test.describe('Visual Regression Tests @visual', () => {
         await page.getByRole('button', { name: 'Truncate migration' }).click();
         await page.getByRole('button', { name: 'Archive' }).click();
 
-        await expect.soft(page).toHaveScreenshot('connection-wizard-truncation.png', { mask });
+        await expectSnapshot(page, 'connection-wizard-truncation.png', { clip: true });
 
         await waitForLoaders(page, 300_000); // wait for truncation
 
@@ -122,6 +119,6 @@ test.describe('Component Visual Tests @visual @components', () => {
         const dashboardCard = page.locator('.swag-migration-dashboard-card');
 
         await expect(dashboardCard).toBeVisible();
-        await expect.soft(dashboardCard).toHaveScreenshot('dashboard-card.png');
+        await expectSnapshot(page, 'dashboard-card.png');
     });
 });

--- a/tests/acceptance/tests/MigrationTest.spec.ts
+++ b/tests/acceptance/tests/MigrationTest.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-disable playwright/no-conditional-in-test */
-/* eslint-disable playwright/no-conditional-expect */
 import { test, expect, replaceElements } from '@fixtures/AcceptanceTest';
-import { getMask, waitForLoaders, withLargerViewport } from '@fixtures/TestHelpers';
+import { expectSnapshot, waitForLoaders } from '@fixtures/TestHelpers';
 
 test.describe('Migration Tests @migration @visual', () => {
     test.describe.configure({
@@ -11,7 +10,6 @@ test.describe('Migration Tests @migration @visual', () => {
 
     test('Perform migration from Shopware 5 to Shopware 6', async ({ ShopAdmin, EntityCounter, MigrationConnection: _ }) => {
         const page = ShopAdmin.page;
-        const mask = getMask(page);
 
         const baseline = await EntityCounter.buildBaseline({
             product: 428,
@@ -52,9 +50,7 @@ test.describe('Migration Tests @migration @visual', () => {
             await page.locator('.swag-migration-tab-card').scrollIntoViewIfNeeded();
             await waitForLoaders(page);
 
-            const restoreViewport = await withLargerViewport(page);
-            await expect.soft(page).toHaveScreenshot('data-selection-assigment-with-errors.png', { mask });
-            await restoreViewport();
+            await expectSnapshot(page, 'data-selection-assigment-with-errors.png');
 
             const tabs = page.locator('.swag-migration-tab-card__title');
 
@@ -75,7 +71,7 @@ test.describe('Migration Tests @migration @visual', () => {
                 }
             }
 
-            await expect.soft(page).toHaveScreenshot('data-selection-assigment-without-errors.png', { mask });
+            await expectSnapshot(page, 'data-selection-assigment-without-errors.png');
         });
 
         await test.step('Start migration', async () => {
@@ -85,7 +81,7 @@ test.describe('Migration Tests @migration @visual', () => {
             await page.getByRole('button', { name: 'Continue anyway' }).click();
             await waitForLoaders(page);
 
-            await expect.soft(page).toHaveScreenshot('migration-process-started.png', { mask });
+            await expectSnapshot(page, 'migration-process-started.png');
 
             const step = page.locator('.sw-step-display > .sw-step-item').first();
             await expect(step).toHaveClass(/sw-step-item--success/, { timeout: 300_000 });
@@ -95,9 +91,7 @@ test.describe('Migration Tests @migration @visual', () => {
         });
 
         await test.step('Error resolution', async () => {
-            let restoreViewport = await withLargerViewport(page);
-            await expect.soft(page).toHaveScreenshot('error-resolution-log-groups-unfixed.png', { mask });
-            await restoreViewport();
+            await expectSnapshot(page, 'error-resolution-log-groups-unfixed.png');
 
             await waitForLoaders(page);
             const logs = page.locator('.sw-data-grid__body .sw-data-grid__cell--actions');
@@ -171,14 +165,14 @@ test.describe('Migration Tests @migration @visual', () => {
                 await processLogEntry(i);
 
                 if (i === 0) {
-                    await expect.soft(page).toHaveScreenshot('error-resolution-log-detail-unfixed.png', { mask });
+                    await expectSnapshot(page, 'error-resolution-log-detail-unfixed.png');
                 }
 
                 await page.getByRole('button', { name: 'Apply changes' }).click();
                 await waitForLoaders(page);
 
                 if (i === 0) {
-                    await expect.soft(page).toHaveScreenshot('error-resolution-log-detail-fixed.png', { mask });
+                    await expectSnapshot(page, 'error-resolution-log-detail-fixed.png');
                 }
 
                 await page.locator('.sw-modal__close').click();
@@ -187,9 +181,7 @@ test.describe('Migration Tests @migration @visual', () => {
 
             await waitForLoaders(page);
 
-            restoreViewport = await withLargerViewport(page);
-            await expect.soft(page).toHaveScreenshot('error-resolution-log-groups-fixed.png', { mask });
-            await restoreViewport();
+            await expectSnapshot(page, 'error-resolution-log-groups-fixed.png');
 
             await expect(page.locator('.swag-migration-error-resolution-step__card-table-count-icon')).toHaveCount(logCount);
 
@@ -210,7 +202,7 @@ test.describe('Migration Tests @migration @visual', () => {
             await waitForLoaders(page);
             await expect(page.getByText('The Migration is done')).toBeVisible({ timeout: 300_000 });
 
-            await expect.soft(page).toHaveScreenshot('migration-process-summary.png', { mask });
+            await expectSnapshot(page, 'migration-process-summary.png');
 
             await page.getByRole('button', { name: 'Back to overview' }).click();
             await waitForLoaders(page);
@@ -224,7 +216,7 @@ test.describe('Migration Tests @migration @visual', () => {
 
             await replaceElements(page, [createdAtCellContent]);
 
-            await expect.soft(page).toHaveScreenshot('migration-history-list.png', { mask });
+            await expectSnapshot(page, 'migration-history-list.png');
 
             await page.locator('.sw-data-grid__body .sw-data-grid__cell--actions').getByRole('button').click();
             await waitForLoaders(page);
@@ -234,7 +226,7 @@ test.describe('Migration Tests @migration @visual', () => {
 
             await replaceElements(page, [createdAtCellContent]);
 
-            await expect.soft(page).toHaveScreenshot('migration-history-details-modal.png', { mask });
+            await expectSnapshot(page, 'migration-history-details-modal.png');
         });
 
         await test.step('Verify migrated entities', async () => {


### PR DESCRIPTION
scope visual snapshots to page and modal

### Changes

- Add `expectSnapshot` helper that captures `.sw-page` (or the open `.sw-modal__dialog`) instead of the full viewport
- Migrate all acceptance visual snapshots in `BasicVisualTest` and `MigrationTest` to `expectSnapshot`