### PR TITLE
test: probe whether the PHPUnit job detects a truncated suite

### DIFF
--- a/tests/CompletionGuardDemoKillerTest.php
+++ b/tests/CompletionGuardDemoKillerTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SwagMigrationAssistant\Test;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal Probe for shopware/shopware#18667 — DO NOT MERGE.
+ *
+ * Simulates code under test terminating the PHPUnit process with a success
+ * exit code (the shopware/shopware#18560 incident class). The suite runs in
+ * random order, so this kills the process after an arbitrary prefix of the
+ * 234 test classes has run.
+ *
+ * Expected outcomes for the "PHPUnit" job of the Integration workflow:
+ * - green  => the job cannot tell a full run from a truncated one, the issue
+ *             is present and needs a fix in this repository.
+ * - red    => platform's CompletionGuard (registered by TestBootstrapper::bootstrap(),
+ *             which tests/TestBootstrap.php calls) already covers this repository.
+ */
+#[Package('fundamentals@after-sales')]
+class CompletionGuardDemoKillerTest extends TestCase
+{
+    public function testExitZeroKillsThePhpunitProcess(): void
+    {
+        exit(0);
+    }
+}


### PR DESCRIPTION
**Probe for [shopware/shopware#18667](https://github.com/shopware/shopware/issues/18667) — do not merge.**

### 1. Why is this change necessary?

shopware/shopware#18667 asks us to give the after-sales plugin PHPUnit jobs the same "the suite really ran" safety net that the platform got in shopware/shopware#18675. Before choosing between the two options in the issue (reuse `.github/actions/phpunit-run/action.yaml`, or reimplement the check here), we need evidence about what this repository's `PHPUnit` job actually detects today.

### 2. What does this change do, exactly?

Adds a single test, `tests/CompletionGuardDemoKillerTest.php`, whose `exit(0)` terminates the PHPUnit process with a success exit code — the shopware/shopware#18560 incident class. `phpunit.xml.dist` runs the suite in `executionOrder="random"`, so the process dies after an arbitrary prefix of the 234 test classes.

The `Run PHPUnit` step of `.github/workflows/action-phpunit.yml` only inspects the exit code, so the outcome of the `PHPUnit` job of the `Integration` workflow answers the question directly:

- **green** — the job cannot distinguish a full run from a truncated one, the issue is present here and needs a fix in this repository.
- **red** — platform's `Shopware\Core\Test\PHPUnit\CompletionGuard`, registered from `TestBootstrapper::bootstrap()` which `tests/TestBootstrap.php` calls, already covers this repository through the `trunk` platform this job installs. The failure message is then "PHPUnit terminated before the test runner finished the suite".

### 3. Describe each step to reproduce the issue or behaviour.

1. Open this PR and let the `Integration` / `PHPUnit` job run.
2. Compare the job result and the tail of the `Run PHPUnit` step output against the two cases above.

### 5. Checklist

- [x] I have created the PR in draft status and only open it when it's ready for review
- [x] This change has code comments where appropriate, especially for non-obvious lines of code
